### PR TITLE
Fixed bug in rev_tcp.py

### DIFF
--- a/modules/payloads/python/meterpreter/rev_tcp.py
+++ b/modules/payloads/python/meterpreter/rev_tcp.py
@@ -8,6 +8,8 @@ By @harmj0y
 
 from modules.common import helpers
 from modules.common import encryption
+from datetime import date
+from datetime import timedelta
 
 class Payload:
     


### PR DESCRIPTION
Added datetime imports to fix bug that would cause a crash when setting a payload to expire. (Happened in 3.14-kali1-amd64)