### PR TITLE
Command line arguments improvements - Number support & checks required options 

### DIFF
--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -101,6 +101,7 @@ class Controller:
         self.payloads = list()
         # a specific payload, so we can set it manually
         self.payload = None
+        self.payloadname = None
         # restrict loaded modules to specific languages
         self.langs = langs
 
@@ -321,6 +322,7 @@ class Controller:
 
                 # set the internal payload variable
                 self.payload = payload
+                self.payloadname = name
 
             # did they enter a number rather than the full payload?
             elif payloadname.isdigit() and 0 < int(payloadname) <= len(self.payloads):
@@ -329,7 +331,7 @@ class Controller:
                     # if the entered number matches the payload #, use that payload
                     if int(payloadname) == x:
                         self.payload = pay
-                        break
+                        self.payloadname = name
                     x += 1
 
         # if a payload isn't found, then list available payloads and exit
@@ -347,8 +349,9 @@ class Controller:
                 self.payload.shellcode.SetPayload(options['msfvenom'])
 
             if not self.ValidatePayload(self.payload):
+                print " Payload: %s\n" % self.payloadname
                 print helpers.color("\n [!] WARNING: Not all required options filled\n", warning=True)
-                # TODO: Display payload name & required options (current values & missing values)
+                self.PayloadOptions(self.payload)
                 sys.exit()
 
         else:
@@ -876,8 +879,8 @@ class Controller:
                                 # if the entered number matches the payload #, use that payload
                                 if int(p) == x:
                                     self.payload = pay
+                                    self.payloadname = name
                                     self.outputFileName = self.PayloadMenu(self.payload, args=args)
-                                    break
                                 x += 1
 
                         # else choosing the payload by name
@@ -886,6 +889,7 @@ class Controller:
                                 # if we find the payload specified, kick off the payload menu
                                 if payloadName == p:
                                     self.payload = pay
+                                    self.payloadname = name
                                     self.outputFileName = self.PayloadMenu(self.payload, args=args)
 
                         cmd = ""
@@ -930,8 +934,8 @@ class Controller:
                                 # if the entered number matches the payload #, use that payload
                                 if int(p) == x:
                                     self.payload = pay
+                                    self.payloadname = name
                                     self.PayloadInfo(self.payload)
-                                    break
                                 x += 1
 
                         # else choosing the payload by name
@@ -940,6 +944,7 @@ class Controller:
                                 # if we find the payload specified, kick off the payload menu
                                 if payloadName == p:
                                     self.payload = pay
+                                    self.payloadname = name
                                     self.PayloadInfo(self.payload)
 
                         cmd = ""
@@ -975,8 +980,8 @@ class Controller:
                         # if the entered number matches the payload #, use that payload
                         if int(cmd) == x:
                             self.payload = pay
+                            self.payloadname = name
                             self.outputFileName = self.PayloadMenu(self.payload, args=args)
-                            break
                         x += 1
                     cmd = ""
                     if settings.TERMINAL_CLEAR != "false": showMessage=True

--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -329,6 +329,7 @@ class Controller:
                     # if the entered number matches the payload #, use that payload
                     if int(payloadname) == x:
                         self.payload = pay
+                        break
                     x += 1
 
         # if a payload isn't found, then list available payloads and exit
@@ -344,6 +345,11 @@ class Controller:
             # options['msfvenom'] = ["windows/meterpreter/reverse_tcp", ["LHOST=192.168.1.1","LPORT=443"]
             if 'msfvenom' in options:
                 self.payload.shellcode.SetPayload(options['msfvenom'])
+
+            if not self.ValidatePayload(self.payload):
+                print helpers.color("\n [!] WARNING: Not all required options filled\n", warning=True)
+                # TODO: Display payload name & required options (current values & missing values)
+                sys.exit()
 
         else:
 
@@ -871,6 +877,7 @@ class Controller:
                                 if int(p) == x:
                                     self.payload = pay
                                     self.outputFileName = self.PayloadMenu(self.payload, args=args)
+                                    break
                                 x += 1
 
                         # else choosing the payload by name
@@ -924,6 +931,7 @@ class Controller:
                                 if int(p) == x:
                                     self.payload = pay
                                     self.PayloadInfo(self.payload)
+                                    break
                                 x += 1
 
                         # else choosing the payload by name
@@ -968,6 +976,7 @@ class Controller:
                         if int(cmd) == x:
                             self.payload = pay
                             self.outputFileName = self.PayloadMenu(self.payload, args=args)
+                            break
                         x += 1
                     cmd = ""
                     if settings.TERMINAL_CLEAR != "false": showMessage=True

--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -322,19 +322,31 @@ class Controller:
                 # set the internal payload variable
                 self.payload = payload
 
-                # options['customShellcode'] = "\x00..."
-                if 'customShellcode' in options:
-                    self.payload.shellcode.setCustomShellcode(options['customShellcode'])
-                # options['required_options'] = {"compile_to_exe" : ["Y", "Compile to an executable"], ...}
-                if 'required_options' in options:
-                    for k,v in options['required_options'].items():
-                        self.payload.required_options[k] = v
-                # options['msfvenom'] = ["windows/meterpreter/reverse_tcp", ["LHOST=192.168.1.1","LPORT=443"]
-                if 'msfvenom' in options:
-                    self.payload.shellcode.SetPayload(options['msfvenom'])
+            # did they enter a number rather than the full payload?
+            elif payloadname.isdigit() and 0 < int(payloadname) <= len(self.payloads):
+                x = 1
+                for (name, pay) in self.payloads:
+                    # if the entered number matches the payload #, use that payload
+                    if int(payloadname) == x:
+                        self.payload = pay
+                    x += 1
 
         # if a payload isn't found, then list available payloads and exit
-        if not self.payload:
+        if self.payload:
+
+            # options['customShellcode'] = "\x00..."
+            if 'customShellcode' in options:
+                self.payload.shellcode.setCustomShellcode(options['customShellcode'])
+            # options['required_options'] = {"compile_to_exe" : ["Y", "Compile to an executable"], ...}
+            if 'required_options' in options:
+                for k,v in options['required_options'].items():
+                    self.payload.required_options[k] = v
+            # options['msfvenom'] = ["windows/meterpreter/reverse_tcp", ["LHOST=192.168.1.1","LPORT=443"]
+            if 'msfvenom' in options:
+                self.payload.shellcode.SetPayload(options['msfvenom'])
+
+        else:
+
             print helpers.color(" [!] Invalid payload selected\n\n", warning=True)
             self.ListPayloads()
             sys.exit()


### PR DESCRIPTION
## Before
_Fails (due to no LHOST being set) but it looks successful!_
```
root@kali ~/veil-Evasion$ python Veil-Evasion.py -p go/meterpreter/rev_http -c LPORT=4400                                                                            1 ↵ master 

=========================================================================
 Veil-Evasion | [Version]: 2.21.2
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================


 Language:		Go
 Payload:		go/meterpreter/rev_http
 Required Options:      COMPILE_TO_EXE=Y  LHOST=  LPORT=4400
 Payload File:		/usr/share/veil-output/source/payload.go
 Handler File:		/usr/share/veil-output/handlers/payload_handler.rc

 [*] Your payload files have been generated, don't get caught!
 [!] And don't submit samples to any online scanner! ;)

root@kali ~/veil-Evasion$
```



## After: 
_Will catch the error and inform (Thanks to #183)._
```
root@kali ~/veil-Evasion$ python Veil-Evasion.py -p 13 -c LPORT=4400                                                                                                        cli 

=========================================================================
 Veil-Evasion | [Version]: 2.21.2
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================

 Payload: go/meterpreter/rev_http


 [!] WARNING: Not all required options filled


 Required Options:

 Name			Current Value	Description
 ----			-------------	-----------
 COMPILE_TO_EXE  	Y       	Compile to an executable
 LHOST           	        	IP of the Metasploit handler
 LPORT           	4400    	

root@kali ~/veil-Evasion$
```