### PR TITLE
Fix check if module uses msfvenom, fixes CLI

### DIFF
--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -327,10 +327,11 @@ class Controller:
                     print helpers.color("\n [!] Internal error #4.", warning=True)
             # options['msfvenom'] = ["windows/meterpreter/reverse_tcp", ["LHOST=192.168.1.1","LPORT=443"]
             if 'msfvenom' in options:
-                if hasattr(options, 'msfvenom'):
+                if hasattr(self.payload, 'shellcode'):
                     self.payload.shellcode.SetPayload(options['msfvenom'])
                 else:
                     print helpers.color("\n [!] Internal error #3: This module does not use msfvenom!", warning=True)
+                    sys.exit()
 
             if not self.ValidatePayload(self.payload):
 


### PR DESCRIPTION
I am not sure if this won't break anything else, so someone must review it, but it fixes CLI ( https://github.com/Veil-Framework/Veil-Evasion/issues/211 )
Also required options (-c) are not added to msfvenom command, is this intentional and you need to add LHOST and LPORT also to --msfoptions ?