### PR TITLE
Go fix

### DIFF
--- a/modules/common/supportfiles.py
+++ b/modules/common/supportfiles.py
@@ -205,7 +205,8 @@ def supportingFiles(payload, payloadFile, options):
     elif language.lower() == "go":
         exeName = ".".join(payloadFile.split("/")[-1].split(".")[:-1]) + ".exe"
 
-        os.system('env GOROOT=/usr/src/go CGO_ENABLED=1 GOOS=windows GOARCH=386 CC=\"i686-w64-mingw32-gcc -fno-stack-protector -D_FORTIFY_SOURCE=0 -lssp\" /usr/src/go/bin/go build -ldflags -H=windowsgui -o ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ' + payloadFile)
+        os.system('env GOROOT=/usr/local/go GOOS=windows GOARCH=386 /usr/bin/go build -ldflags -H=windowsgui -v -o ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ' + payloadFile)
+        #os.system('mv ' + payloadFile.split('.')[0] + '.exe ' + settings.PAYLOAD_COMPILED_PATH + exeName)
 
         if settings.TERMINAL_CLEAR != "false": messages.title()
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -294,7 +294,7 @@ func_go_deps(){
   # Use 1.5.2 to compile 1.5.3
   export GOROOT_BOOTSTRAP=/usr/src/go-go1.5.2
   mkdir /usr/src/go1.5.3
-  $currentdir=`pwd`
+  currentdir=`pwd`
   cd /usr/src/go1.5.3
   git clone https://go.googlesource.com/go
   cd go

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -296,10 +296,12 @@ func_go_deps(){
   mkdir /usr/src/go1.5.3
   $currentdir = `pwd`
   cd /usr/src/go1.5.3
-  git clone https://go.googlecode.com/go
+  git clone https://go.googlesource.com/go
+  cd go
   git checkout go1.5.3
   cd src
   ./all.bash
+  export GOROOT=/usr/src/go1.5.3/go
   cd $currentdir
   
   # Done

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -288,22 +288,13 @@ func_go_deps(){
 
   if [ ! -f "/usr/src/go/bin/windows_386/go.exe" ]; then
     echo -e "${BOLD} [*] Installing Go (via TAR)${RESET}"
-    sudo tar -xf "${rootdir}/setup/go1.5.2.tar.gz" -C /usr/src/   #wget -q https://github.com/golang/go/archive/go1.5.2.tar.gz
+    wget https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz
+    tar -C /usr/local -xvf go1.5.3.linux-amd64.tar.gz
+    export GOROOT=/usr/local/go
+    rm /usr/bin/go
+    ln -s /usr/local/go/bin/go /usr/bin/go
   fi
 
-  # Use 1.5.2 to compile 1.5.3
-  export GOROOT_BOOTSTRAP=/usr/src/go-go1.5.2
-  mkdir /usr/src/go1.5.3
-  currentdir=`pwd`
-  cd /usr/src/go1.5.3
-  git clone https://go.googlesource.com/go
-  cd go
-  git checkout go1.5.3
-  cd src
-  ./all.bash
-  export GOROOT=/usr/src/go1.5.3/go
-  cd $currentdir
-  
   # Done
   popd >/dev/null
 }

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -291,20 +291,17 @@ func_go_deps(){
     sudo tar -xf "${rootdir}/setup/go1.5.2.tar.gz" -C /usr/src/   #wget -q https://github.com/golang/go/archive/go1.5.2.tar.gz
   fi
 
-  # Compile
-  export GOROOT=/usr/src/go-go1.5.2/
-  #export GOROOT_BOOTSTRAP=$GOROOT
-  cd "${GOROOT}/src/"
-  sudo env GOROOT_BOOTSTRAP=/usr ./make.bash
-  tmp="$?"
-  [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Compile Go... Exit Code: ${tmp}.${RESET}...\n" && exit 1
-
-  # Cross-Compile
-  sudo env GOROOT_BOOTSTRAP=/usr GOOS=windows GOARCH=386 ./make.bash --no-clean
-  sudo env GOROOT_BOOTSTRAP=/usr GOOS=windows GOARCH=386 CGO_ENABLED=1 CC_FOR_TARGET="i686-w64-mingw32-gcc -fno-stack-protector -D_FORTIFY_SOURCE=0 -lssp" ./make.bash --no-clean
-  tmp="$?"
-  [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Cross-Compile Go... Exit Code: ${tmp}.${RESET}...\n" && exit 1
-
+  # Use 1.5.2 to compile 1.5.3
+  export GOROOT_BOOTSTRAP=/usr/src/go-go1.5.2
+  mkdir /usr/src/go1.5.3
+  $currentdir = `pwd`
+  cd /usr/src/go1.5.3
+  git clone https://go.googlecode.com/go
+  git checkout go1.5.3
+  cd src
+  ./all.bash
+  cd $currentdir
+  
   # Done
   popd >/dev/null
 }

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -294,7 +294,7 @@ func_go_deps(){
   # Use 1.5.2 to compile 1.5.3
   export GOROOT_BOOTSTRAP=/usr/src/go-go1.5.2
   mkdir /usr/src/go1.5.3
-  $currentdir = `pwd`
+  $currentdir=`pwd`
   cd /usr/src/go1.5.3
   git clone https://go.googlesource.com/go
   cd go


### PR DESCRIPTION
This is a fix for the GO install process for Veil-Evasion.  This actually makes my life a lot easier now that I figured out a better way of doing this.  I'm not really sure why, but I've been constantly compiling Go from source.  It's a million times easier to just use a pre-compiled version of Go, and I want run into any of the problems that I've had.