### PR TITLE
User home directory Wine environments and additional distribution support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # OSX
 .DS_Store
+
+# Editor Swap Files
+*.swp

--- a/Veil-Evasion.py
+++ b/Veil-Evasion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Front end launcher for the Veil AV-evasion framework.

--- a/config/update.py
+++ b/config/update.py
@@ -38,6 +38,11 @@ def generateConfig(options):
     config += 'TERMINAL_CLEAR="' + options['TERMINAL_CLEAR'] + '"\n\n'
     print " [*] TERMINAL_CLEAR = " + options['TERMINAL_CLEAR']
 
+    config += '# Wine environment\n'
+    config += 'import os\n'
+    config += 'os.environ["WINEPREFIX"]="' + options["WINEPREFIX"] + '"\n\n'
+    print " [*] WINEPREFIX = " + options["WINEPREFIX"]
+
     config += '# Path to temporary directory\n'
     config += 'TEMP_DIR="' + options["TEMP_DIR"] + '"\n\n'
     print " [*] TEMP_DIR = " + options["TEMP_DIR"]
@@ -193,6 +198,19 @@ if __name__ == '__main__':
         # last of the general options
         options["TEMP_DIR"] = "/tmp/"
         options["MSFVENOM_OPTIONS"] = ""
+
+        # Get the real user if we're being ran under sudo
+        wineprefix = ""
+        try:
+            user = os.environ.get("SUDO_USER")
+            if user == 'root':
+                wineprefix = "/root/.config/wine/veil/"
+            else:
+                wineprefix = "/home/" + user + "/.config/wine/veil/"
+        except KeyError:
+            print(" [*] Unable to get user from SUDO_USER environment variable\n")
+            print("     Your WINEPREFIX option might be screwed. You can fix it in /etc/veil/settings.py")
+        options["WINEPREFIX"] = wineprefix
 
         # Veil-Evasion specific options
         veil_evasion_path = "/".join(os.getcwd().split("/")[:-1]) + "/"

--- a/config/update.py
+++ b/config/update.py
@@ -39,8 +39,7 @@ def generateConfig(options):
     print " [*] TERMINAL_CLEAR = " + options['TERMINAL_CLEAR']
 
     config += '# Wine environment\n'
-    config += 'import os\n'
-    config += 'os.environ["WINEPREFIX"]="' + options["WINEPREFIX"] + '"\n\n'
+    config += 'WINEPREFIX="' + options["WINEPREFIX"] + '"\n\n'
     print " [*] WINEPREFIX = " + options["WINEPREFIX"]
 
     config += '# Path to temporary directory\n'

--- a/modules/common/supportfiles.py
+++ b/modules/common/supportfiles.py
@@ -123,18 +123,18 @@ def supportingFiles(payload, payloadFile, options):
 
             # Check for Wine python.exe Binary (Thanks to darknight007 for this fix.)
             # Thanks to Tim Medin for patching for non-root non-kali users
-            #if (architecture == "32" \
-            #    and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')\
-            #   ) or ( architecture == "64" \
-            #    and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')):
-            #    # Tim Medin's Patch for non-root non-kali users
-            #    if settings.TERMINAL_CLEAR != "false": messages.title()
-            #    if architecture == "32":
-            #        print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
-            #    else:
-            #        print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
-            #    print helpers.color(" [!] ERROR: Make sure the python.exe binary exists before using PyInstaller.", warning=True)
-            #    sys.exit()
+            if (architecture == "32" \
+                and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')\
+               ) or ( architecture == "64" \
+                and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')):
+                # Tim Medin's Patch for non-root non-kali users
+                if settings.TERMINAL_CLEAR != "false": messages.title()
+                if architecture == "32":
+                    print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
+                else:
+                    print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
+                print helpers.color(" [!] ERROR: Make sure the python.exe binary exists before using PyInstaller.", warning=True)
+                sys.exit()
 
             # extract the payload base name and turn it into an .exe
             exeName = ".".join(payloadFile.split("/")[-1].split(".")[:-1]) + ".exe"
@@ -142,11 +142,9 @@ def supportingFiles(payload, payloadFile, options):
             # TODO: os.system() is depreciated, use subprocess or commands instead
             random_key = helpers.randomString()
             if architecture == "64":
-                #os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine64 ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
-                os.system('WINEPREFIX=~/.config/wine/veil/ wine64 ' + os.path.expanduser('~/.config/wine/veil/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile )
+                os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine64 ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
             else:
-                #os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
-                os.system('WINEPREFIX=~/.config/wine/veil/ wine ' + os.path.expanduser('~/.config/wine/veil/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
+                os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
 
             if settings.TERMINAL_CLEAR != "false": messages.title()
 

--- a/modules/common/supportfiles.py
+++ b/modules/common/supportfiles.py
@@ -123,18 +123,18 @@ def supportingFiles(payload, payloadFile, options):
 
             # Check for Wine python.exe Binary (Thanks to darknight007 for this fix.)
             # Thanks to Tim Medin for patching for non-root non-kali users
-            if (architecture == "32" \
-                and not os.path.isfile(os.path.expanduser('~/.wine/drive_c/Python27/python.exe'))\
-               ) or ( architecture == "64" \
-                and not os.path.isfile(os.path.expanduser('~/.wine/drive_c/Python27/python.exe'))):
-                # Tim Medin's Patch for non-root non-kali users
-                if settings.TERMINAL_CLEAR != "false": messages.title()
-                if architecture == "32":
-                    print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser('~/.wine/drive_c/Python27/'), warning=True)
-                else:
-                    print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser('~/.wine64/drive_c/Python27/'), warning=True)
-                print helpers.color(" [!] ERROR: Make sure the python.exe binary exists before using PyInstaller.", warning=True)
-                sys.exit()
+            #if (architecture == "32" \
+            #    and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')\
+            #   ) or ( architecture == "64" \
+            #    and not os.path.isfile(settings.WINEPREFIX + 'drive_c/Python27/python.exe')):
+            #    # Tim Medin's Patch for non-root non-kali users
+            #    if settings.TERMINAL_CLEAR != "false": messages.title()
+            #    if architecture == "32":
+            #        print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
+            #    else:
+            #        print helpers.color("\n [!] ERROR: Can't find python.exe in " + os.path.expanduser(settings.WINEPREFIX + 'drive_c/Python27/'), warning=True)
+            #    print helpers.color(" [!] ERROR: Make sure the python.exe binary exists before using PyInstaller.", warning=True)
+            #    sys.exit()
 
             # extract the payload base name and turn it into an .exe
             exeName = ".".join(payloadFile.split("/")[-1].split(".")[:-1]) + ".exe"
@@ -142,9 +142,11 @@ def supportingFiles(payload, payloadFile, options):
             # TODO: os.system() is depreciated, use subprocess or commands instead
             random_key = helpers.randomString()
             if architecture == "64":
-                os.system('WINEPREFIX=~/.wine64 wine64 ' + os.path.expanduser('~/.wine64/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile )
+                #os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine64 ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
+                os.system('WINEPREFIX=~/.config/wine/veil/ wine64 ' + os.path.expanduser('~/.config/wine/veil/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile )
             else:
-                os.system('wine ' + os.path.expanduser('~/.wine/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
+                #os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine ' + settings.WINEPREFIX + '/drive_c/Python27/python.exe' + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
+                os.system('WINEPREFIX=~/.config/wine/veil/ wine ' + os.path.expanduser('~/.config/wine/veil/drive_c/Python27/python.exe') + ' ' + os.path.expanduser(settings.PYINSTALLER_PATH + '/pyinstaller.py') + ' --noconsole --onefile --key ' + random_key + ' ' + payloadFile)
 
             if settings.TERMINAL_CLEAR != "false": messages.title()
 
@@ -194,7 +196,7 @@ def supportingFiles(payload, payloadFile, options):
         # extract the payload base name and turn it into an .exe
         exeName = ".".join(payloadFile.split("/")[-1].split(".")[:-1]) + ".exe"
 
-        os.system('wine ~/.wine/drive_c/Ruby187/bin/ruby.exe ~/.wine/drive_c/Ruby187/bin/ocra --windows '+ payloadFile + ' --output ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ~/.wine/drive_c/Ruby187/lib/ruby/gems/1.8/gems/win32-api-1.4.8-x86-mingw32/lib/win32/*')
+        os.system('WINEPREFIX=' + settings.WINEPREFIX + ' wine ' + settings.WINEPREFIX + '/drive_c/Ruby187/bin/ruby.exe ' + settings.WINEPREFIX + '/drive_c/Ruby187/bin/ocra --windows '+ payloadFile + ' --output ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ' + settings.WINEPREFIX + '/drive_c/Ruby187/lib/ruby/gems/1.8/gems/win32-api-1.4.8-x86-mingw32/lib/win32/*')
 
         if settings.TERMINAL_CLEAR != "false": messages.title()
 

--- a/modules/payloads/python/shellcode_inject/letter_substitution.py
+++ b/modules/payloads/python/shellcode_inject/letter_substitution.py
@@ -83,7 +83,7 @@ class Payload:
                 payload_code += shellcode_variable_name + ' = bytearray(' + subbed_shellcode_variable_name + '.decode(\"string_escape\"))\n'
                 payload_code += rand_ptr + ' = ' + randctypes + '.windll.kernel32.VirtualAlloc(' + randctypes + '.c_int(0),' + randctypes + '.c_int(len(' + shellcode_variable_name + ')),' + randctypes + '.c_int(0x3000),' + randctypes + '.c_int(0x40))\n'
                 payload_code += rand_buf + ' = (' + randctypes + '.c_char * len(' + shellcode_variable_name + ')).from_buffer(' + shellcode_variable_name + ')\n'
-                payload_code += ranctypes + '.windll.kernel32.RtlMoveMemory(' + randctypes + '.c_int(' + rand_ptr + '),' + rand_buf + ',' + randctypes + '.c_int(len(' + shellcode_variable_name + ')))\n'
+                payload_code += randctypes + '.windll.kernel32.RtlMoveMemory(' + randctypes + '.c_int(' + rand_ptr + '),' + rand_buf + ',' + randctypes + '.c_int(len(' + shellcode_variable_name + ')))\n'
                 payload_code += rand_ht + ' = ' + randctypes + '.windll.kernel32.CreateThread(' + randctypes + '.c_int(0),' + randctypes + '.c_int(0),' + randctypes + '.c_int(' + rand_ptr + '),' + randctypes + '.c_int(0),' + randctypes + '.c_int(0),' + randctypes + '.pointer(' + randctypes + '.c_int(0)))\n'
                 payload_code += randctypes + '.windll.kernel32.WaitForSingleObject(' + randctypes + '.c_int(' + rand_ht + '),' + randctypes + '.c_int(-1))\n'
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -236,28 +236,9 @@ func_package_deps(){
       python-pip ca-certificates msttcore-fonts-installer
   elif [ "${os}" ==  "arch" ]; then
     sudo pacman -Sy ${arg} --needed mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-mingw-w64-winpthreads \
-      mono mono-tools mono-addins python-pip wget unzip ruby python python2 python-crypto gcc-go ca-certificates base-devel
-    if [ -f /usr/bin/yaourt ]; then
-      echo -e " [I] ${YELLOW}Setting up yaourt to install packages from AUR...${RESET}"
-      cd /tmp
-      sudo -u ${trueuser} git clone https://aur.archlinux.org/package-query.git
-      # Let the users confirm for now, since some might be iffy about it
-      # makepkg does not let you run as root. Arch users expect this behaviour.
-      cd package-query
-      sudo -u ${trueuser} makepkg --needed -Ccsi
-      cd /tmp
-      sudo -u ${trueuser} git clone https://aur.archlinux.org/yaourt.git
-      cd yaourt
-      sudo -u ${trueuser} makepkg --needed -Ccsi
-      cd ${rootdir}
-      echo -e "\n [!] ${YELLOW}Installing python-pefile-git from AUR. https://aur.archlinux.org/packages/python-pefile-git"
-      echo -e "     Yaourt will prompt you for your password as it's safer to build under your user: ${trueuser}.${RESET}\n"
-      sudo -u ${trueuser} yaourt -S python-pefile-git
-    else
-      echo -e "\n [!] ${YELLOW}Installing python-pefile-git from AUR. https://aur.archlinux.org/packages/python-pefile-git"
-      echo -e "     Yaourt will prompt you for your password as it's safer to build under your user: ${trueuser}.${RESET}\n"
-      sudo -u ${trueuser} yaourt -S python-pefile-git
-    fi
+      mono mono-tools mono-addins python2-pip wget unzip ruby python python2 python-crypto gcc-go ca-certificates base-devel
+    # Install pefile for python2 using pip, rather than via AUR as the package is currently broken.
+    sudo pip2 install pefile
   fi
   tmp="$?"
   [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Dependencies... Exit Code: ${tmp}.${RESET}\n" && exit 1
@@ -276,10 +257,10 @@ func_capstone_deps(){
     [[ "${silent}" == "true" ]] && arg="DEBIAN_FRONTEND=noninteractive"
     sudo ${arg} apt-get -y install python-capstone
   else
-    which pip >/dev/null 2>&-
+    which pip2 >/dev/null 2>&-
     if [ "$?" -eq 0 ]; then
       echo -e ${BOLD}' [*] Installing Capstone (via PIP)'${RESET}
-      sudo pip install capstone
+      sudo pip2 install capstone
     else    # In theory, we should never end up here
       echo -e ${BOLD}' [*] Installing Capstone (via Source)'${RESET}
       git clone https://github.com/aquynh/capstone "${rootdir}/setup/capstone/"
@@ -323,7 +304,7 @@ func_python_deps(){
         sudo ${arg} apt-get install -y python-symmetric-jsonrpc
       else
         echo -e "\n [*] ${YELLOW}Installing SymmetricJSONRPC Dependency (via PIP)...${RESET}"
-        sudo pip install symmetricjsonrpc
+        sudo pip2 install symmetricjsonrpc
       fi
     fi
   done

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -2,8 +2,25 @@
 
 
 # Global Variables
+arch="$(uname -m)"
 runuser="$(whoami)"
+trueuser="$(who am i | awk '{print $1}')" # if this is blank, we're actually root (kali)
+# Edge cases... urgh. There *was* a reason it's like this. It'll get tested further
+# later and get cleaned up as required in a later patch.
+if [ "$runuser" == "root" ] && [ "$trueuser" == "" ]; then
+  trueuser="root"
+fi
+if [ "$trueuser" != "root" ]; then
+  userhomedir=$(echo /home/${trueuser})
+else
+  userhomedir=$HOME
+fi
+userprimarygroup="$(id -Gn "${trueuser}" | awk '{print $1}')"
 rootdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd)
+winedir="${userhomedir}/.config/wine/veil"
+winedrive="${userhomedir}/.config/wine/veil/drive_c"
+WINEPREFIX="${userhomedir}/.config/wine/veil"
+nukewinedir=""
 silent=false
 os="$(awk -F '=' '/^ID=/ {print $2}' /etc/os-release 2>&-)"
 version=$(awk -F '=' '/^VERSION_ID=/ {print $2}' /etc/os-release 2>&-)
@@ -15,19 +32,25 @@ GREEN="\033[01;32m"    # Success
 YELLOW="\033[01;33m"   # Warnings/Information
 RESET="\033[00m"       # Normal
 
-
 ########################################################################
-
-
 # Title Function
 func_title(){
   # Echo Title
   echo '=========================================================================='
-  echo ' Veil-Evasion (Setup Script) | [Updated]: 2016-01-20'
+  echo ' Veil-Evasion (Setup Script) | [Updated]: 2016-02-23'
   echo '=========================================================================='
   echo ' [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework'
   echo '=========================================================================='
   echo -e '\n'
+  #echo -e "Debug:       WINEPREFIX = ${WINEPREFIX}"
+  #echo -e "Debug:          winedir = ${winedir}"
+  #echo -e "Debug:        winedrive = ${winedrive}"
+  #echo -e "Debug:      userhomedir = ${HOME}"
+  #echo -e "Debug:          rootdir = ${rootdir}"
+  #echo -e "Debug:         trueuser = ${trueuser}"
+  #echo -e "Debug: userprimarygroup = ${userprimarygroup}"
+  #echo -e "Debug:               os = ${os}"
+  #echo -e "Debug:          version = ${version}"
 }
 
 # Environment Checks
@@ -40,7 +63,8 @@ func_check_env(){
     echo '          Please Install and Configure sudo Then Run This Setup Again.'
     echo '          Example: For Debian/Ubuntu: apt-get -y install sudo'
     echo '                   For Fedora 22+: dnf -y install sudo'
-    echo ''
+    echo "${YELLOW}\n\n[!] Before you begin the install, make sure that you have the metasploit\n"
+    echo "    framework installed. We are not going to hold your hand!\n${RESET}"
     exit 1
   fi
 
@@ -66,14 +90,14 @@ func_check_env(){
   fi
 
   # Check If (Wine) Python Is Already Installed
-  if [ -f ~/.wine/drive_c/Python27/python27.dll ] && [ -f ~/.wine/drive_c/Python27/python.exe ] && [ -f ~/.wine/drive_c/Python27/Lib/site-packages/win32/win32api.pyd ]; then
+  if [ -f ${winedrive}/Python27/python27.dll ] && [ -f ${winedrive}/Python27/python.exe ] && [ -f ${winedrive}/Python27/Lib/site-packages/win32/win32api.pyd ]; then
     echo -e ${YELLOW}'\n\n [*] (Wine) Python Already Installed... Skipping...'${RESET}
   else
     func_python_deps
   fi
 
   # Check If (Wine) Ruby Is Already Installed
-  if [ -f ~/.wine/drive_c/Ruby187/bin/ruby.exe ] && [ -d ~/.wine/drive_c/Ruby187/lib/ruby/gems/1.8/gems/win32-api-1.4.8-x86-mingw32/lib/win32/ ]; then
+  if [ -f ${winedrive}/Ruby187/bin/ruby.exe ] && [ -d ${winedrive}/Ruby187/lib/ruby/gems/1.8/gems/win32-api-1.4.8-x86-mingw32/lib/win32/ ]; then
     echo -e ${YELLOW}'\n\n [*] (Wine) Ruby Already Installed... Skipping...'${RESET}
   else
     func_ruby_deps
@@ -96,33 +120,100 @@ func_check_env(){
 
 # Install Architecture Dependent Dependencies
 func_package_deps(){
-  echo -e ${YELLOW}'\n\n [*] Initializing Package Installation'${RESET}
+  echo -e "\n\n [*] ${YELLOW}Initializing Package Installation${RESET}"
 
-  # Update Repository For Debian based OSs, yum/dnf doesn't need this step
+  # Begin Wine install for multiple architectures
+  # Always install 32bit support for 64bit architectures
+
+  # Debian based distributions
   if [ "${os}" == "ubuntu" ] || [ "${os}" == "debian" ] || [ "${os}" == "kali" ]; then
-    sudo apt-get -q update
+
     if [ "${silent}" == "true" ]; then
-      echo -e ${YELLOW}'\n\n [*] Silent Mode: Enabled'${RESET}
+      echo -e "\n\n [*]${YELLOW} Silent Mode: Enabled ${RESET}"
       arg="DEBIAN_FRONTEND=noninteractive"
+    fi
+
+    if [ "${arch}" == "x86_64" ]; then
+      echo -e "\n [*] ${YELLOW}Adding x86 Architecture To x86_64 System for Wine${RESET}"
+      sudo dpkg --add-architecture i386
+      sudo apt-get -qq update
+      echo -e " [*] ${YELLOW}Installing Wine 32bit and 64bit Binaries${RESET}"
+      if [ "${os}" != "ubuntu" ]; then
+        sudo ${arg} apt-get -y -qq install wine wine64 wine32
+      else # Special snowflakes... urghbuntu
+        sudo ${arg} apt-get -y -qq install wine wine1.6 wine1.6-i386
+      fi
+      tmp="$?"
+      [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed to install Wine... Exit Code: ${tmp}.${RESET}\n" && exit 1
+    elif [ ${arch} == 'x86' ]; then
+      sudo apt-get -qq udpate
+      sudo ${arg} apt-get -y -qq install wine32
+      tmp="$?"
+      [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Wine... Exit Code: ${tmp}.${RESET}\n" && exit 1
+    else # Dead code. We really shouldn't end up here, but, you never know...
+      "${RED} [!] CRITICAL ERROR: Architecture ${arch} is not supported!"
+      exit 1
+    fi
+
+    # Red Hat based distributions
+  elif [ "${os}" == "fedora" ] || [ "${os}" == "rhel" ] || [ "${os}" == "centos" ]; then
+    echo -e "${YELLOW}\n\n [*] Installing Wine 32-bit on x86_64 System${RESET}\n"
+    sudo dnf install -y wine.i686 wine
+    tmp="$?"
+    [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Wine x86_64... Exit Code: ${tmp}.${RESET}\n" && exit 1
+  fi
+
+  # Setup Wine prefices
+  # Because Veil currently only supports Win32 binaries, we have to set the WINEARCH PREFIX
+  # to use Win32. This is a potential issue for the future when Veil has windows 64bit 
+  # binary support. To get around this in setup and somewhat future proof for that eventuality, 
+  # we're already going to look for an existing veil wine setup (~/.config/veil/) and nuke it 
+  # making it easy for a user to rerun the setup and have a new wine environment.
+  if [ -d "${winedir}" ]; then
+    echo -e "\n\n [*]${RED} ALERT: Existing Veil Wine environment detected at ${winedir}${RESET}\n"
+    read -p "            Do you want to nuke it? (recommended) [Y/n]: " nukewinedir
+    if [ "${nukewinedir}" == 'y' ]; then
+      echo -e "\n\n [*]${YELLOW} Deleting existing Veil Wine environment...${RESET}\n"
+      rm -rf "${winedir}"
+    else
+      echo -e " [*] ${YELLOW} Maintaining current Veil Wine environment...${RESET}"
     fi
   fi
 
-  # Check For 64-bit Kernel
-  if [ $(uname -m) == 'x86_64' ]; then
-    if [ "${os}" == "ubuntu" ] || [ "${os}" == "debian" ] || [ "${os}" == "kali" ]; then
-      echo -e ${YELLOW}'\n\n [*] Adding i386 Architecture To x86_64 System'${RESET}
-      sudo dpkg --add-architecture i386
-      sudo apt-get -q update
+  # For creating wine environment on newer distros
+  if [ -f "/usr/bin/wineboot" ]; then
+    winebootexists=true
+  else
+    winebootexists=false
+  fi
 
-      echo -e ${YELLOW}'\n\n [*] Installing (Wine) i386 Binaries'${RESET}
-      sudo ${arg} apt-get -y install wine32   #wine-bin:i386
-      tmp="$?"
-      [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Wine x86_64... Exit Code: ${tmp}.${RESET}\n" && exit 1
-    else
-      echo -e '\n\n [*] Installing Wine 32-bit on x86_64 System'
-      sudo dnf install -y wine.i686
-      tmp="$?"
-      [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Wine x86_64... Exit Code: ${tmp}.${RESET}\n" && exit 1
+  if [ "${nukewinedir}" == 'y' ] || [ ! -d "${winedir}" ]; then
+    echo -e " [*]${YELLOW} Creating new Veil Wine environment in ${winedir} ${RESET}"
+    if [ "${arch}" == "x86_64" ]; then
+      echo -e " [*]${YELLOW} Initializing Veil's Wine environment...${RESET}"
+      if [ $winebootexists == true ]; then
+        sudo -u ${trueuser} mkdir -p "${winedrive}"
+        sudo -u ${trueuser} WINEARCH=win32 WINEPREFIX="${WINEPREFIX}" wineboot -u
+      else
+        sudo -u ${trueuser} WINEARCH=win32 WINEPREFIX="${WINEPREFIX}" wine cmd.exe /c ipconfig >/dev/null
+      fi
+      # Sorta-kinda check for the existence of the wine drive
+      if [ -d "${winedrive}" ]; then
+        echo -e " [*]${GREEN} Veil Wine environment successfully created!\n${RESET}"
+      else
+        echo -e " [ERROR]${RED} Veil Wine environment could not be found!\n${RESET}"
+        echo -e "${RED}         Check for existence of ${winedrive}\n${RESET}"
+        exit 1
+      fi
+    elif [ "${arch}" == "x86" ]; then
+      echo -e "${YELLOW} [*] Initializing Veil's Wine environment...${RESET}\n"
+      sudo -u ${trueuser} WINEPREFIX=${winedir} wineboot -u
+      if [ -d "${winedrive}" ]; then
+        echo -e "${GREEN} Veil Wine environment successfully created!\n${RESET}"
+      else
+        echo -e "${RED} [ERROR] Veil Wine environment could not be found!"
+        echo -e "${RED}         Check for existence of ${winedrive}\n${RESET}"
+      fi
     fi
   fi
 
@@ -130,11 +221,11 @@ func_package_deps(){
   echo -e ${YELLOW}'\n\n [*] Installing Dependencies'${RESET}
   if [ "${os}" == "ubuntu" ] || [ "${os}" == "debian" ] || [ "${os}" == "kali" ]; then
     sudo ${arg} apt-get -y install mingw-w64 monodoc-browser monodevelop mono-mcs wine unzip ruby golang wget git \
-                                   python python-crypto python-pefile python-pip ca-certificates ttf-mscorefonts-installer
+      python python-crypto python-pefile python-pip ca-certificates #ttf-mscorefonts-installer
   elif [ "${os}" == "fedora" ] || [ "${os}" == "rhel" ] || [ "${os}" == "centos" ]; then
     sudo ${arg} dnf -y install mingw64-binutils mingw64-cpp mingw64-gcc mingw64-gcc-c++ mono-tools-monodoc monodoc \
-                               monodevelop mono-tools mono-core wine unzip ruby golang wget git python python-crypto python-pefile \
-                               python-pip ca-certificates msttcore-fonts-installer
+      monodevelop mono-tools mono-core wine unzip ruby golang wget git python python-crypto python-pefile \
+      python-pip ca-certificates msttcore-fonts-installer
   fi
   tmp="$?"
   [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install Dependencies... Exit Code: ${tmp}.${RESET}\n" && exit 1
@@ -148,7 +239,7 @@ func_package_deps(){
 
 # Install Capstone Dependencies (Needed for Backdoor Factory. https://github.com/secretsquirrel/the-backdoor-factory/blob/master/install.sh)
 func_capstone_deps(){
-  echo -e ${YELLOW}'\n\n [*] Installing Capstone Dependencies...'${RESET}
+  echo -e "\n [*] ${YELLOW}Installing Capstone Dependencies...${RESET}"
   if [ "${os}" == "kali" ]; then
     [[ "${silent}" == "true" ]] && arg="DEBIAN_FRONTEND=noninteractive"
     sudo ${arg} apt-get -y install python-capstone
@@ -168,7 +259,7 @@ func_capstone_deps(){
       sudo make install
       cd "${rootdir}/setup/"
       sudo rm -rf "capstone/"
-      echo -e ${YELLOW}'\n\n [*] Adding Capstone Library Path To /etc/ls.so.conf.d/capstone.conf'${RESET}
+      echo -e "\n [*] ${YELLOW}Adding Capstone Library Path To /etc/ld.so.conf.d/capstone.conf${RESET}"
       sudo sh -c "echo '# Capstone Shared Libs' > /etc/ld.so.conf.d/capstone.conf"
       sudo sh -c "echo '/usr/lib64' >> /etc/ld.so.conf.d/capstone.conf"
       sudo ldconfig
@@ -180,17 +271,17 @@ func_capstone_deps(){
 
 # Install Python Dependencies
 func_python_deps(){
-  echo -e ${YELLOW}'\n\n [*] Initializing (Wine) Python Dependencies Installation...'${RESET}
+  echo -e "\n [*] ${YELLOW}Initializing (Wine) Python Dependencies Installation...${RESET}"
 
   # Check If SymmetricJSONRPC Is Already Installed
   if [ -d /usr/local/lib/python2.7/dist-packages/symmetricjsonrpc/ ]; then
-    echo -e ${YELLOW}'\n\n [*] SymmetricJSONRPC Already Installed... Skipping...'${RESET}
+    echo -e "\n [*] ${YELLOW}SymmetricJSONRPC Already Installed... Skipping...${RESET}"
   elif [ "${os}" == "kali" ]; then
-    echo -e ${YELLOW}'\n\n [*] Installing SymmetricJSONRPC Dependency (via Repository)'${RESET}
+    echo -e "\n [*] ${YELLOW}Installing SymmetricJSONRPC Dependency (via Repository)${RESET}"
     [[ "${silent}" == "true" ]] && arg="DEBIAN_FRONTEND=noninteractive"
     sudo ${arg} apt-get -y install python-symmetric-jsonrpc
   else
-    echo -e ${YELLOW}'\n\n [*] Installing SymmetricJSONRPC Dependency (via PIP)...'${RESET}
+    echo -e "\n [*] ${YELLOW}Installing SymmetricJSONRPC Dependency (via PIP)...${RESET}"
     sudo pip install symmetricjsonrpc
     echo ''
   fi
@@ -199,45 +290,44 @@ func_python_deps(){
 
   # Incase Its 'First Time Run' for WINE (More information: http://wiki.winehq.org/Mono)
   [[ "${silent}" == "true" ]] && bash "${rootdir}/setup/install-addons.sh"   #wget -qO - "http://winezeug.googlecode.com/svn/trunk/install-addons.sh"
-  wine cmd.exe /c ipconfig >/dev/null
 
   # Prepare (Wine) Directories - Required Before Python
-  echo -e ${YELLOW}'\n\n [*] Preparing (Wine) Directories...'${RESET}
-  mkdir -p ~/.wine/drive_c/Python27/Lib/site-packages/ ~/.wine/drive_c/Python27/Scripts/
-  unzip -q -o -d ~/.wine/drive_c/Python27/Lib/ "${rootdir}/setup/python-distutils.zip"
-  unzip -q -o -d ~/.wine/drive_c/Python27/ "${rootdir}/setup/python-tcl.zip"
-  unzip -q -o -d ~/.wine/drive_c/Python27/ "${rootdir}/setup/python-Tools.zip"
+  echo -e "${YELLOW}\n [*] Preparing Wine Python Directories...${RESET}"
+  sudo -u ${trueuser} mkdir -p "${winedrive}/Python27/Lib/site-packages/" "${winedrive}/Python27/Scripts/"
+  sudo -u ${trueuser} unzip -q -o -d "${winedrive}/Python27/Lib/" "${rootdir}/setup/python-distutils.zip"
+  sudo -u ${trueuser} unzip -q -o -d "${winedrive}/Python27/" "${rootdir}/setup/python-tcl.zip"
+  sudo -u ${trueuser} unzip -q -o -d "${winedrive}/Python27/" "${rootdir}/setup/python-Tools.zip"
 
   # Install Setup Files
-  echo -e ${YELLOW}'\n\n [*] Installing (Wine) Python...'${RESET}
+  echo -e "\n [*]${YELLOW} Installing (Wine) Python...${RESET}"
   echo -e ${BOLD}' [*] Next -> Next -> Next -> Finished! ...Overwrite if prompt. Use default values.'${RESET}
   [ "${silent}" == "true" ] && arg="TARGETDIR=C:\Python27 ALLUSERS=1 /q"
-  wine msiexec /i "${rootdir}/setup/python-2.7.5.msi" ${arg}
+  sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine msiexec /i "${rootdir}/setup/python-2.7.5.msi ${arg}"
   tmp="$?"
   [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install (Wine) Python 2.7.5... Exit Code: ${tmp}.${RESET}\n" && exit 1
 
   sleep 3s
 
-  echo -e ${YELLOW}'\n\n [*] Installing (Wine) Python Dependencies...'${RESET}
+  echo -e "\n [*] ${YELLOW}Installing (Wine) Python Dependencies...${RESET}"
   pushd "${rootdir}/setup/" >/dev/null
   for FILE in pywin32-219.win32-py2.7.exe pycrypto-2.6.win32-py2.7.exe; do
     echo -e "\n\n${YELLOW} [*] Installing Python's ${FILE}...${RESET}"
     if [ "${silent}" == "true" ]; then
-      unzip -q -o "${FILE}"
-      cp -rf PLATLIB/* ~/.wine/drive_c/Python27/Lib/site-packages/
-      [ -e "SCRIPTS" ] && cp -rf SCRIPTS/* ~/.wine/drive_c/Python27/Scripts/
+      sudo -u ${trueuser} unzip -q -o "${FILE}"
+      sudo -u ${trueuser} cp -rf PLATLIB/* ${winedrive}/Python27/Lib/site-packages/
+      [ -e "SCRIPTS" ] && sudo -u ${trueuser} cp -rf SCRIPTS/* ${winedrive}/Python27/Scripts/
       rm -rf "PLATLIB/" "SCRIPTS/"
     else
       echo -e ${BOLD}' [*] Next -> Next -> Next -> Finished! ...Overwrite if prompt. Use default values.'${RESET}
-      wine "${FILE}"
+      sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine "${FILE}"
       tmp="$?"
       [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install ${FILE}... Exit Code: ${tmp}.${RESET}\n" && exit 1
     fi
   done
 
-  echo -e ${YELLOW}'\n\n [*] Installing (Wine) Python Dependencies - pywin32...'${RESET}
-  echo -e ${BOLD}' [*] Next -> Next -> Next -> Finished! ...Overwrite if prompt. Use default values.'${RESET}
-  wine C://Python27//python.exe C://Python27//Scripts//pywin32_postinstall.py -install
+  echo -e " [*]${YELLOW} Installing (Wine) Python Dependencies - pywin32...${RESET}"
+  echo -e "${BOLD} [*] Next -> Next -> Next -> Finished! ...Overwrite if prompt. Use default values. ${RESET}"
+  sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine "C://Python27//python.exe" "C://Python27//Scripts//pywin32_postinstall.py -install"
 
   popd >/dev/null
 
@@ -246,7 +336,7 @@ func_python_deps(){
   [[ "${silent}" == "true" ]] && arg="DEBIAN_FRONTEND=noninteractive"
   if [ -f "/usr/share/pyinstaller/PKG-INFO" ]; then
     pyinstversion=`sed -n '3{p;q;}' /usr/share/pyinstaller/PKG-INFO | cut -d' ' -f2`
-    if [ "$pyinstversion" == "3.1.1"]; then
+    if [ "$pyinstversion" == "3.1.1" ]; then
       echo "PyInstaller version 3.1.1 is already installed, skipping!"
     else
       # Install pyinstaller now
@@ -271,9 +361,10 @@ func_python_deps(){
     fi
   fi
 
-  if [ ! -f "${rootdir}/.wine/drive_c/Python27/Lib/site-packages/setuptools-0.6c11-py2.7.egg-info" ]; then
+  # Check to see if setup tools is available, if not, install it.
+  if [ ! -f "${winedrive}/Python27/Lib/site-packages/setuptools-0.6c11-py2.7.egg-info" ]; then
     wget https://www.veil-framework.com/InstallMe/distribute_setup.py
-    wine /root/.wine/drive_c/Python27/python.exe distribute_setup.py
+    sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine ${winedrive}/Python27/python.exe distribute_setup.py
     rm distribute_setup.py
   fi
 }
@@ -284,7 +375,7 @@ func_go_deps(){
   # help for this setup came from:
   # http://www.limitlessfx.com/cross-compile-golang-app-for-windows-from-linux.html
 
-  echo -e ${YELLOW}'\n\n [*] Initializing Go Dependencies Installation...'${RESET}
+  echo -e " [*]${YELLOW} Initializing Go Dependencies Installation...${RESET}"
   pushd "/tmp/" >/dev/null
 
   sudo mkdir -p /usr/src/go/
@@ -293,7 +384,7 @@ func_go_deps(){
     goversion="$(apt-cache show golang-src | awk -F '[:-.]' '/Version/ {print $3$4}')"
     if [[ ! $(grep "#*deb-src" /etc/apt/sources.list) ]] && [ "${goversion}" -gt "12" ]; then
       # Download source via Repository
-      echo -e "${BOLD} [*] Installing Go (v${goversion} via Repository)${RESET}"
+      echo -e " [*]${BOLD} Installing Go (v${goversion} via Repository)${RESET}"
       sudo apt-get source golang-go  #golang
       tmp="$?"
       [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Download Go... Exit Code: ${tmp}.${RESET}\n" && exit 1
@@ -307,26 +398,26 @@ func_go_deps(){
   fi
 
   if [ ! -f "/usr/src/go/bin/windows_386/go.exe" ]; then
-    echo -e "${BOLD} [*] Installing Go (via TAR)${RESET}"
-    if [ $(uname -m) == 'x86_64' ]; then
+    echo -e " [*]${BOLD} Installing Go (via TAR)${RESET}"
+    if [ ${arch} == 'x86_64' ]; then
       wget https://www.veil-framework.com/InstallMe/go153x64.tar.gz
       shasum1=`openssl dgst -sha256 go153x64.tar.gz | cut -d' ' -f2`
       if [ "$shasum1" == "43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53" ]; then
         sudo tar -C /usr/local -xvf go153x64.tar.gz
         sudo rm go153x64.tar.gz
       else
-        echo "HASH MISMATCH!  Run again, or alert developer!!!!"
+        echo "${RED}HASH MISMATCH!  Run again, or alert developer!!!!${RESET}"
         exit
       fi
     fi
-    if [ $(uname -m) == 'i686' ]; then
+    if [ ${arch} == 'i686' ]; then
       wget https://www.veil-framework.com/InstallMe/go153x86.tar.gz
       shasum2=`openssl dgst -sha256 go153x86.tar.gz | cut -d' ' -f2`
       if [ "$shasum2" == "c1ce206b7296db1b10ff7896044d9ca50e87efa5bc3477e8fd8c2fb149bfca8f" ]; then
         sudo tar -C /usr/local -xvf go153x86.tar.gz
         sudo rm go153x86.tar.gz
       else
-        echo "HASH MISMATCH!  Run again, or alert developer!!!!"
+        echo "${RED}HASH MISMATCH!  Run again, or alert developer!!!!${RESET}"
         exit
       fi
     fi
@@ -341,49 +432,63 @@ func_go_deps(){
 
 # Install (Wine) Ruby Dependencies
 func_ruby_deps(){
-  echo -e ${YELLOW}'\n\n [*] Initializing (Wine) Ruby Dependencies Installation...'${RESET}
+  echo -e "\n [*] ${YELLOW}Initializing (Wine) Ruby Dependencies Installation...${RESET}"
 
   pushd "${rootdir}/setup/" >/dev/null
 
   # Install Ruby Under Wine
-  echo -e ${YELLOW}'\n\n [*] Installing (Wine) Ruby & Dependencies'${RESET}
+  echo -e "\n [*] ${YELLOW}Installing (Wine) Ruby & Dependencies${RESET}"
   echo -e ${BOLD}' [*] Next -> Next -> Next -> Finished! ...Overwrite if prompt. Use default values.'${RESET}
-  mkdir -p ~/.wine/drive_c/Ruby187/lib/ruby/gems/1.8/
+  sudo -u ${trueuser} mkdir -p "${winedrive}/Ruby187/lib/ruby/gems/1.8/"
 
   [ "${silent}" == "true" ] && arg="/silent"
-  wine "${rootdir}/setup/rubyinstaller-1.8.7-p371.exe" "${arg}"
+  sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine "${rootdir}/setup/rubyinstaller-1.8.7-p371.exe ${arg}"
   tmp="$?"
   [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install (Wine) Ruby.exe... Exit Code: ${tmp}.${RESET}\n" && exit 1
 
   # Install the OCRA Gem Under Wine
-  wine ~/.wine/drive_c/Ruby187/bin/ruby.exe ~/.wine/drive_c/Ruby187/bin/gem install ocra-1.3.0.gem
+  echo -e " [*]${YELLOW} Installing Wine Ruby OCRA gem...${RESET}"
+  sudo -u ${trueuser} WINEPREFIX=${WINEPREFIX} wine "${winedrive}/Ruby187/bin/ruby.exe" "${winedrive}/Ruby187/bin/gem" install ocra-1.3.0.gem 
   tmp="$?"
   [ "${tmp}" -ne "0" ] && echo -e " ${RED}[ERROR] Failed To Install (Wine) OCRA Gem... Exit Code: ${tmp}.${RESET}\n" && exit 1
 
   # Unzip the Ruby Dependencies
-  unzip -q -o -d ~/.wine/drive_c/Ruby187/lib/ruby/gems/1.8/ "${rootdir}/setup/ruby_gems-1.8.zip"
+  echo -e " [*]${YELLOW} Extracting Wine Ruby dependencies...${RESET}"
+  sudo -u ${trueuser} unzip -q -o -d "${winedrive}/Ruby187/lib/ruby/gems/1.8/" "${rootdir}/setup/ruby_gems-1.8.zip"
 
   popd >/dev/null
 }
 
 # Update Veil Config
 func_update_config(){
-  # ./config/update.py
-  echo -e ${YELLOW}'\n\n [*] Updating Veil-Framework Configuration...'${RESET}
+  echo -e "\n [*] ${YELLOW}Updating Veil-Framework Configuration...${RESET}"
   cd "${rootdir}/config/"
-  sudo python update.py
+
+  # SUDOINCEPTION! (There is method behind the, at first glance, madness)
+  # The SUDO_USER environment variable of the actual user doesn't get passed on to the python interpreter properly,
+  # so when we call "sudo python update.py", it thinks the user calling it, it's interpretation of SUDO_USER is root,
+  # and that's not what we want. Look at this fake process tree with what the env variables would be...
+  #    - |_ sudo setup.sh ($USER=root $SUDO_USER=yourname)
+  #      - | sudo -u yourname sudo python update.py ($USER=root $SUDO_USER=yourname)
+  # snip 8<-  -  -  -  -  -  -  -  -  -  -  -  -  - The alternative below without "sudo -u username"...
+  #      - | sudo python update.py ($USER=root $SUDO_USER=root)
+  # snip 8<-  -  -  -  -  -  -  -  -  -  -  -  -  - And thus it would have screwed up the $WINEPREFIX dir for the user.
+  sudo -u ${trueuser} sudo python update.py
 
   mkdir -p "${outputfolder}"
 
   # Chown Output Directory
   if [ -d "${outputfolder}" ]; then
-    echo -e "\n\n [*] Ensuring this account (${runuser}) owns veil output directory (${outputfolder})..."
-    sudo chown -R "${runuser}" "${outputfolder}"
+    echo -e "\n [*] ${YELLOW}Ensuring this account (${trueuser}) owns veil output directory (${outputfolder})...${RESET}"
+    sudo chown -R "${trueuser}" "${outputfolder}"
   else
     echo -e " ${RED}[ERROR] Internal Issue. Couldn't create output folder...${RESET}\n"
   fi
-}
 
+  # Ensure that user completely owns the wine directory
+  echo -e " [*] ${YELLOW}Ensuring this account (${trueuser}) has correct ownership of ${winedir}${RESET}"
+  chown -R ${trueuser}:${userprimarygroup} ${winedir}
+}
 
 ########################################################################
 
@@ -391,29 +496,34 @@ func_update_config(){
 # Print Banner
 func_title
 
+# Check Architecture
+if [ "${arch}" != "x86" ] && [ "${arch}" != "x86_64" ]; then
+  echo -e "${RED} [ERROR] Your architecture ${arch} is not supported!\n\n${RESET}"
+  exit 1
+fi
 
 # Check OS
 if [ -z "${os}" ] || [ -z "${version}" ]; then
   echo -e " ${RED}[ERROR] Internal Issue. Couldn't Detect OS Information...${RESET}\n"
   exit 1
 elif [ "${os}" == "kali" ]; then
-  echo " [i] Kali Linux ${version} $(uname -m) Detected..."
+  echo -e " [I]${YELLOW} Kali Linux ${version} ${arch} Detected...${RESET}\n"
 elif [ "${os}" == "ubuntu" ]; then
   version=$(awk -F '["=]' '/^VERSION_ID=/ {print $3}' /etc/os-release 2>&- | cut -d'.' -f1)
-  echo " [i] Ubuntu ${version} $(uname -m) Detected..."
-  if [[ "${version}" -lt "14" ]]; then
-    echo -e " [ERROR]: Veil-Evasion Only Supported On Ubuntu 14+.\n"
+  echo -e "${YELLOW} [I] Ubuntu ${version} ${arch} Detected...${RESET}\n"
+  if [[ "${version}" -lt "15" ]]; then
+    echo -e "${RED} [ERROR]: Veil-Evasion Only Supported On Ubuntu 15.10+.\n${RESET}"
     exit 1
   fi
 elif [ "${os}" == "debian" ]; then
-  echo " [i] Debian ${version} $(uname -m) Detected..."
-  if [ "${version}" -lt "7" ]; then
-    echo -e " [ERROR]: Veil-Evasion Only Supported On Debian 7+.\n"
-    exit 1
+  echo -e "[I]${YELLOW} Debian ${version} ${arch} Detected...${RESET}\n"
+  if [ ${version} -lt 7 ]; then
+    echo -e " [ERROR]${red} Only Debian 8 (Jessie) and above are supported!\n"
   fi
 elif [ "${os}" == "fedora" ]; then
+  echo "${YELLOW} [I] Fedora ${version} ${arch} detected...\n${RESET}"
   if [[ "${version}" -lt "22" ]]; then
-    echo -e " [ERROR]: Veil-Evasion only supported on Fedora 22+.\n"
+    echo -e "${RED} [ERROR]: Veil-Evasion only supported on Fedora 22+.\n${RESET}"
     exit 1
   fi
 fi
@@ -423,45 +533,45 @@ fi
 case $1 in
   # Make Sure Not To Nag The User
   -s|--silent)
-    silent=true
-    func_check_env
-    ;;
+  silent=true
+  func_check_env
+  ;;
 
   # Force Clean Install Of (Wine) Python Dependencies
   # Bypass Environment Checks (func_check_env) To Force Install Dependencies
   -c|--clean)
-    func_package_deps
-    func_capstone_deps
-    func_python_deps
-    func_ruby_deps
-    func_go_deps
-    func_update_config
-    ;;
+  func_package_deps
+  func_capstone_deps
+  func_python_deps
+  func_ruby_deps
+  func_go_deps
+  func_update_config
+  ;;
 
   # Print Help Menu
   -h|--help)
-    echo ''
-    echo "  [Usage]....: ${0} [OPTIONAL]"
-    echo '  [Optional].:'
-    echo '               -c|--clean    = Force Clean Install Of Any Dependencies'
-    echo '               -s|--silent   = Automates the installation'
-    echo '               -h|--help     = Show This Help Menu'
-    echo ''
-    exit 0
-    ;;
+  echo ''
+  echo "  [Usage]....: ${0} [OPTIONAL]"
+  echo '  [Optional].:'
+  echo '               -c|--clean    = Force Clean Install Of Any Dependencies'
+  echo '               -s|--silent   = Automates the installation'
+  echo '               -h|--help     = Show This Help Menu'
+  echo ''
+  exit 0
+  ;;
 
   # Run Standard Setup
   "")
-    func_check_env
+  func_check_env
   ;;
 
-  *)
-    echo -e "\n\n [ERROR] Unknown Option: $1"
-    exit 1
-    ;;
+*)
+  echo -e "\n\n [ERROR] Unknown Option: $1"
+  exit 1
+  ;;
 esac
 
 file=$(dirname "$(readlink -f "$0")")"/setup.sh"
-echo -e '\n\n [i] If you have any errors running Veil-Evasion, delete your WINE profile (rm -rf ~/.wine/) and re-run: '${file}
-echo -e '\n\n [i] Done!'
+echo -e "\n [I] If you have any errors running Veil-Evasion, delete the Veil Wine profile (rm -rf '${winedir}') and re-run: '${file}"
+echo -e "\n [I] ${GREEN}Done!${RESET}"
 exit 0

--- a/tools/backdoor/install.sh
+++ b/tools/backdoor/install.sh
@@ -6,7 +6,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 #install capstone
-pip install capstone
+pip2 install capstone
 
 uname -a | grep BSD &> /dev/null
 if [ $? -eq 0 ]; then
@@ -26,8 +26,8 @@ fi
 
 #install pefile
 #check for pip
-if hash pip 2>/dev/null; then
-        pip install pefile
+if hash pip2 2>/dev/null; then
+        pip2 install pefile
 else
         echo 'Install pefile manually, pip is not installed'
         echo ""


### PR DESCRIPTION
Changes I proposed to @ChrisTruncer last week via email concerning the installer. This is the first PR from that proposal.

The premise behind this was simply to begin to allow non-root users be able to run Veil Evasion and add additional distribution support. This required setting up wine environments inside the user's home directory and allowing the wine environment to be nuked from the installer if a previous environment is found. This required segregating off the Veil environment from one that a user might previously have on their system and we wouldn't want to interfere with it. As such, the location for this is now ~/.config/wine/veil/.

Additional distribution support has been opened up with this PR. Veil-Evasion installation now works on Arch Linux, Debian 8, Debian sid/testing and Ubuntu 15.10. Additional distribution support will be added by me on request if people really need it. The current Fedora support in there will get shored up in a future PR if people request it.

Another future PR that I have planned will get the installer filesystem spew under control and make sure everything stays within ~/.config/wine/veil.

The changes have been tested on the following distributions: Kali Linux 2, Debian 8, Ubuntu 15.10 and Arch Linux. Currently it installs and runs on all of those platforms. Some simple binaries have been put through Veil by myself but it would awesome if some other folks could help me test that these changes won't break anything for anyone's day-to-day operation.

I highly welcome comments and suggestions on how to improve this further. You'll catch me idling in #Veil on IRC.