### PR TITLE
This is a mitigation for a security vulnerability with Veil-Evasions RPC server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+[03.29.2016]
+     Released.: 2.25
+     Fixed....: Security vulnerability reported to us by @botnet_hunter.  There was an issue with the RPC server when binding to 0.0.0.0 that essentially allowed RCE.  If you weren't using the RPC server, you weren't affected, but it's good to patch.
+     Thanks...: Thanks to Brian Wallace (@botnet_hunter) for reporting this vulnerability and allowing us to push a patch.
+
 [02.16.2016]
      Released.: 2.24
      Added....: I've added obfuscation to the python payloads.  Some AVs are triggering on ctypes being referenced everywhere, at the moment, it's only in the file once.

--- a/Veil-Evasion.py
+++ b/Veil-Evasion.py
@@ -213,7 +213,7 @@ def runRPC(port=4242):
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     #  Start listening on the socket for connections
-    s.bind(('', port))
+    s.bind(('127.0.0.1', port))
     s.listen(1)
 
     # Create a server thread handling incoming connections

--- a/modules/common/messages.py
+++ b/modules/common/messages.py
@@ -8,7 +8,7 @@ import settings
 import helpers
 
 
-version = "2.24"
+version = "2.25"
 
 
 # try to find and import the settings.py config file


### PR DESCRIPTION
This fixes an issue reported to us by Brian Wallace (@botnet_hunter).  The RPC server essentially binds to 0.0.0.0 and has an issue where it's not properly sanitizing its input.  Brian was able to provide proof of concept attack code that exploited this vulnerability.

This pull request is not a complete fix for the issue, but at least a mitigation.  The RPC server is now binding to 127.0.0.1 vs. 0.0.0.0.  The parsing input will need to be looked at next, but I wanted to provide at least a quick push that would limit the exposure.

Thanks again to Brian for reporting this to me.