### PR TITLE
Strip newlines when setting trueuser in setup.sh

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -13,7 +13,7 @@ arg=""
 outputfolder="/usr/share/veil-output/"
 runuser="$(whoami)"
 if [ "${os}" == "ubuntu" ] || [ "${os}" == "arch" ]; then
-  trueuser="$(who | awk '{print $1}')"
+  trueuser="$(who | tr -d '\n' | awk '{print $1}')"
 else
   trueuser="$(who am i | awk '{print $1}')" # if this is blank, we're actually root (kali)
 fi


### PR DESCRIPTION
Ran into an issue on XFCE where each instance of the terminal tab actually creates a new tty. 

```
username@computer /p/a/v/V/setup> who
username    tty7         2016-07-19 22:01 (:0)
username    pts/0        2016-07-19 22:01 (:0.0)
username    pts/4        2016-07-20 18:33 (tmux(9039).%0)
username    pts/5        2016-07-20 18:33 (tmux(9039).%1)
username    pts/6        2016-07-20 18:34 (tmux(9039).%2)
username    pts/7        2016-07-20 21:52 (:0.0)
username    pts/8        2016-07-21 08:05 (:0.0)
````

So trueuser ended up being set as multiple instances of the username, which broke everything.

```
username@computer /p/a/v/V/setup> who | awk '{print $1}'
username
username
username
username
username
username
username
```

Adding `tr -d "\n"` fixes this issue.
```
username@computer /p/a/v/V/setup> who | tr -d '\n' | awk '{print $1}' 
username
```

I've tested this out and it doesn't seem to have a negative effect if there's just one username returned from `who`. This should be a harmless merge.

Let me know if there's anything else you'd like me to test out on this.