### PR TITLE
Strip Go Binary.

### DIFF
--- a/modules/common/supportfiles.py
+++ b/modules/common/supportfiles.py
@@ -206,7 +206,7 @@ def supportingFiles(payload, payloadFile, options):
     elif language.lower() == "go":
         exeName = ".".join(payloadFile.split("/")[-1].split(".")[:-1]) + ".exe"
 
-        os.system('env GOROOT=/usr/local/go GOOS=windows GOARCH=386 /usr/bin/go build -ldflags -H=windowsgui -v -o ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ' + payloadFile)
+        os.system('env GOROOT=/usr/local/go GOOS=windows GOARCH=386 /usr/bin/go build -ldflags "-s -w -H=windowsgui" -v -o ' + settings.PAYLOAD_COMPILED_PATH + exeName + ' ' + payloadFile)
         #os.system('mv ' + payloadFile.split('.')[0] + '.exe ' + settings.PAYLOAD_COMPILED_PATH + exeName)
 
         if settings.TERMINAL_CLEAR != "false": messages.title()


### PR DESCRIPTION
Takes the Go binary from ~1.3MB to ~770KB by removing the symbol and debug
info.