### PR TITLE
docs: fix simple typo, obsfuscation -> obfuscation

### DIFF
--- a/modules/common/supportfiles.py
+++ b/modules/common/supportfiles.py
@@ -443,7 +443,7 @@ def pwnstallerGenerateMain():
     extractionpathName = helpers.randomString()
     rcName = helpers.randomString()
 
-    # same obsfuscation as used in Veil-Evasion's c/meterpreter/* payloads
+    # same obfuscation as used in Veil-Evasion's c/meterpreter/* payloads
 
     # max length string for obfuscation
     global_max_string_length = 10000


### PR DESCRIPTION
There is a small typo in modules/common/supportfiles.py.

Should read `obfuscation` rather than `obsfuscation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md